### PR TITLE
Added clarification to the use of "PALATTE_FORCE" in versions >= 6.0.

### DIFF
--- a/en/mapfile/outputformat.txt
+++ b/en/mapfile/outputformat.txt
@@ -233,7 +233,8 @@ FORMATOPTION [option]
          triple: OUTPUTFORMAT; FORMATOPTION; PALETTE_FORCE
 
       - "PALETTE_FORCE=on" is used to reduce image depth with a predefined palette.
-        This option is incompatible with the previous quantization options.
+        To allow additional colours for anti-aliasing other than those in the 
+        predefined palette, use with "QUANTIZE_COLORS".
 
 .. index::
    pair: OUTPUTFORMAT; IMAGEMODE


### PR DESCRIPTION
In MapServer < 6, setting a palette forcing it's use automatically used remaining palette space for anti-aliasing colours.

In MapServer >= 6, unless you add QUANTIZE_COLORS=a large enough number (such as 256-n colours in palette file), the only colours used to create the output image are those in the palette file.
