### PR TITLE
add double quote around REGION values as it seems mandatory

### DIFF
--- a/en/mapfile/cluster.txt
+++ b/en/mapfile/cluster.txt
@@ -86,7 +86,7 @@ Mapfile Snippet
     ...
     CLUSTER
        MAXDISTANCE 20  # in pixels
-       REGION ellipse  # can be rectangle or ellipse
+       REGION "ellipse"  # can be rectangle or ellipse
        GROUP (expression)  # an expression to create separate groups for each value
        FILTER (expression) # a logical expression to specify the grouping condition
     END


### PR DESCRIPTION
values for REGION parameter seems to need double quoted. MS send an error on ellipse symbol when no double quote is used: 
`getString(): Symbol definition error. Parsing error near (ellipse):(line 2652)`
