### PR TITLE
Fixed broken links in en/introduction.txt

### DIFF
--- a/en/introduction.txt
+++ b/en/introduction.txt
@@ -868,25 +868,24 @@ Reporting bugs
 Bugs (software and documentation) are reported on the `MapServer  issue
 tracker <http://trac.osgeo.org/mapserver>`__.
 
-Gallery
-...............................................................................
-
-See `examples <http://gallery.osgeo.org>`__ (*currently shut down*) of
-existing MapServer applications.
+.. Gallery
+.. ...............................................................................
+.. 
+.. See `examples <http://gallery.osgeo.org>`__ (*currently shut down*) of
+.. existing MapServer applications.
 
 Tutorial
 ...............................................................................
-
-Perry Nacionales built a great `Tutorial
-<http://biometry.gis.umn.edu/tutorial/>`__ on how to build a MapServer
-application (MapServer  version 5).
-
+ 
+`Here <http://www.mapserver.org/en/tutorial/>`__ is a quick tutorial for new users.
+  
+ 
 Test Suite 
 ...............................................................................
-
-Download the `MapServer Test Suite
-<http://noah.dnr.state.mn.us/mapserver_demos/tests46/>`__ for a
-demonstration of some MapServer functionality.
+ 
+Download the `MapServer Test Suite <https://github.com/mapserver/mapserver/wiki/Test-Suite/>`__ for a demonstration of 
+some MapServer functionality.
+ 
 
 Books 
 ...............................................................................


### PR DESCRIPTION
Corrected two broken links in "Tutorial" and "Test-Suite" sections of en/introduction.html.

Commented out the "Gallery" section, since the gallery is currently down.
