### PR TITLE
add comment about read only tileset and zoom

### DIFF
--- a/en/mapcache/config.txt
+++ b/en/mapcache/config.txt
@@ -406,7 +406,12 @@ given *format*.
 
    <tileset name="test">
 
-      <!-- source: the "name" attribute of a preconfigured <source> -->
+      <!-- source: the "name" attribute of a preconfigured <source>
+          If the tileset does not contain a <source> element, then it is
+          considered read only and the caches will never be updated. In that
+          sense you would have a slightly different mapcache.xml file for your
+          seeder than for your webserver.
+          As for returning blank tiles, you have the <errors> directive that does that (set it to empty_img) -->
       <source>vmap0</source>
 
       <!-- cache: the "name" attribute of a preconfigured <cache> -->
@@ -419,11 +424,13 @@ given *format*.
          cached are not invalidated should you want to modify the restricted extent in the future. When using
          the restricted_extent attribute, you should give the corresponding information to the client that will
          be using the service.
-
+         
+         You can also limit the zoom levels that are cached/accessible by using the minzoom, maxzoom attributes.
+         
          NOTE: when adding a <grid> element, you *MUST* make sure that the source you have selected is able to
          return images in the grid's srs.
       -->
-         <grid restricted_extent="-10 40 10 50">WGS84</grid>
+         <grid restricted_extent="-10 40 10 50" minzoom="4" maxzoom="17">WGS84</grid>
          <grid>g</grid>
 
       <!-- metadata


### PR DESCRIPTION
From http://osgeo-org.1560.x6.nabble.com/MapCache-returning-blank-tiles-when-outside-restricted-extents-td4373381.html  for the read only tileset
and from the https://github.com/mapserver/mapcache/blob/master/mapcache.xml.sample for the min max zoom restriction
