### PR TITLE
Emacs Editing (mapserver-mode).

### DIFF
--- a/en/development/editing/emacs.txt
+++ b/en/development/editing/emacs.txt
@@ -1,0 +1,67 @@
+.. _emacs:
+
+*****************************************************************************
+ Emacs Syntax 
+*****************************************************************************
+
+.. contents:: Table of Contents
+    :depth: 2
+    :backlinks: top
+
+
+
+mapserver-mode for Emacs
+========================
+
+There is a mapserver-mode for Emacs available at:
+`https://github.com/AxxL/mapserver-emacs-mode
+<https://github.com/AxxL/mapserver-emacs-mode>`__ This mode allows
+syntax-highlighting and code-indentation when a Mapserver mapfile is opened
+in Emacs.
+
+Please report issues directly via Github or via the mapserver-users
+list. There are still some issues around.
+
+
+
+Installation
+============
+
+You can grab the neccessary file at:
+`https://github.com/AxxL/mapserver-emacs-mode/blob/master/mapserver-mode.el
+<https://github.com/AxxL/mapserver-emacs-mode/blob/master/mapserver-mode.el>`__
+
+Put it into: $HOME/.emacs.d/lisp/
+
+You need to add the following lines to your $HOME/.emacs.d/init.el
+
+(autoload 'mapserver-mode "mapserver-mode" "Mode for editing UMN MapServer files." t)
+(add-to-list 'auto-mode-alist '("\\.map\\'" . mapserver-mode))
+
+If you haven't specified your load-path it is a good idea to do it now. Put
+the following line before the other two lines.
+
+(add-to-list 'load-path "~/.emacs.d/lisp")
+
+Some help for Emacs is available at the `Emacs Wiki <http://www.emacswiki.org/>`__
+
+
+
+Background
+==========
+
+This file is a fork of Hal Muellers mapserver-mode which he announced nearly
+`10 years ago at the mapserver-users list
+<http://lists.osgeo.org/pipermail/mapserver-users/2004-May/051493.html>`__. I
+simply updated the keywords and constants to the newest version and adjusted
+the regular expressions a bit.
+
+The original file seems to be based on the `Mode Tutorial by Scott Andrew
+Borton <http://www.emacswiki.org/emacs/ModeTutorial>`__. See also the
+`Sample Major Mode example by Stefan Monnier
+<http://www.emacswiki.org/emacs/SampleMode>`__ if you want to write your own
+mode.
+
+In combination with yasnippet and auto-complete-mode you should have a nice
+way to edit mapfiles in your beloved Emacs environment.
+

--- a/en/development/editing/index.txt
+++ b/en/development/editing/index.txt
@@ -9,3 +9,4 @@
    :maxdepth: 1
 
    vim
+   emacs


### PR DESCRIPTION
Description and Link to Emacs editing via mapserver-mode.
http://lists.osgeo.org/pipermail/mapserver-users/2014-August/076866.html
