### PR TITLE
fall back to earlier check-crlf version

### DIFF
--- a/.github/workflows/check-crlf.yml
+++ b/.github/workflows/check-crlf.yml
@@ -12,4 +12,4 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Use action to check for CRLF endings
-        uses: erclu/check-crlf@v1
+        uses: erclu/check-crlf@v1.0.0


### PR DESCRIPTION
- issue with recent 'exclude' directories changes in the v1 release of erclu/check-crlf/pull/1, so fall back to v1.0.0 while issues are resolved.