### PR TITLE
update ISO metadata standards information

### DIFF
--- a/en/ogc/layer_metadata.txt
+++ b/en/ogc/layer_metadata.txt
@@ -9,7 +9,7 @@
 
 :Author:       Tom Kralidis
 :Contact:      tomkralidis at gmail.com
-:Last Updated: 2017-04-04
+:Last Updated: 2020-10-12
 
 .. contents::
     :depth: 2
@@ -51,7 +51,8 @@ itself points to MapServer's `GetMetadata` API.  Example:
 Supported Metadata Formats
 ==========================
 
-MapServer's layer API supports the `ISO 19115:2003`_ geospatial standard.
+MapServer's layer API supports the `ISO 19115-1:2014`_ geospatial standard, via
+`ISO 19139-1:2019` as the XML representation.
 
 The Layer Metadata API
 ======================
@@ -80,4 +81,5 @@ Layer Metadata Support Through CGI
 .. #### rST Link Section ####
 
 .. _`MS RFC 82: Support for Enhanced Layer Metadata Management`: https://mapserver.org/development/rfc/ms-rfc-82.html
-.. _`ISO 19115:2003`: https://www.iso.org/standard/26020.html
+.. _`ISO 19115-1:2014`: https://www.iso.org/standard/53798.html
+.. _`ISO 19139-1:2019`: https://www.iso.org/standard/67253.html


### PR DESCRIPTION
cc @geographika 

Updates ISO metadata standards names per discussion at https://lists.osgeo.org/pipermail/mapserver-users/2020-October/081901.html (related: mapserver/mapserver#6166, mapserver/mapserver#6169).