### PR TITLE
include migration guide in PDF (fixes #55) [build_translations]

### DIFF
--- a/en/documentation.txt
+++ b/en/documentation.txt
@@ -68,6 +68,14 @@ MapCache
   :maxdepth: 2
 
   mapcache/index
+  
+Migration Guide
+.......................................................
+
+.. toctree::
+  :maxdepth: 2
+
+  MIGRATION_GUIDE  
 
 Input
 .......................................................


### PR DESCRIPTION
- while working on the PDF today I noticed that the migration guide is not included
- in fact this was an old ticket #55
- this adds it to the documentation index