### PR TITLE
Update symbol.txt to mention use of SVG symbols

### DIFF
--- a/en/mapfile/symbol.txt
+++ b/en/mapfile/symbol.txt
@@ -122,8 +122,8 @@ FONT [string]
    :name: mapfile-symbol-image
     
 IMAGE [string]
-    Image (GIF or PNG) to use as a marker or brush for type `pixmap`
-    symbols.
+    Filename of image to use as a marker. For type `pixmap`, use
+    GIF or PNG files; for type `svg`, use SVG.
 
 .. index::
    pair: SYMBOL; NAME


### PR DESCRIPTION
Update documentation to take into account that IMAGE is used for SVG files as well as per:
https://mapserver.org/development/rfc/ms-rfc-73.html#usage-example

Are JPG files also supported? Couldn't find the relevant code to verify.