### PR TITLE
enable versionremoved directive

### DIFF
--- a/_static/sphinx.css
+++ b/_static/sphinx.css
@@ -233,6 +233,14 @@ div.versionadded {
 div.versionchanged {
     background-color: #eee;
 }
+
+div.versionremoved {
+    background-color: #ffe4e4;
+}
+
+div.removed-in {
+    background-color: #ffe4e4;
+}
  
 p.admonition-title {
     display: inline;

--- a/conf.py
+++ b/conf.py
@@ -25,7 +25,7 @@ sys.path.append(os.path.abspath('.'))
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 #extensions = ['labels' ,'rst2pdf.pdfbuilder']
 #extensions = ['labels', 'sphinxcontrib.spelling']
-extensions = ['labels']
+extensions = ['labels', 'sphinx_removed_in']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/en/development/documentation.txt
+++ b/en/development/documentation.txt
@@ -8,7 +8,7 @@
 :Contact: hobu.inc at gmail.com
 :Author:  Jeff McKenna
 :Contact: jmckenna at gatewaygeomatics.com
-:Last Updated: 2021-03-18
+:Last Updated: 2021-03-19
 
 .. contents:: Table of Contents
     :depth: 4
@@ -138,14 +138,25 @@ reStructuredText Formatting
   ::
 
       :Last Updated: 2021-02-16
+      
+* Directives `versionadded`, `deprecated`, `versionremoved` should be placed 
+  directly below the parameter name, such as:
+  
+  ::
+  
+    PARAMETER
+      .. deprecated:: 8.0
+         Use a :ref:`xxx` block instead.
 
 Installing and Using Sphinx for rst-html Generation
 ---------------------------------------------------
 
 .. note::
    
-    As of 2020-05-09 the MapServer site requires at least Sphinx 3.0.0 and alabaster 0.7.12 - You can 
-    check the exact versions that the live website uses in the file `requirements.txt <https://github.com/MapServer/MapServer-documentation/blob/main/requirements.txt/>`__, 
+    As of 2021-03-19 the MapServer site requires at least Sphinx 3.5.0, 
+    alabaster 0.7.12, and the `sphinx-removed-in` extension - You can check 
+    the exact versions that the live website uses in the file 
+    `requirements.txt <https://github.com/MapServer/MapServer-documentation/blob/main/requirements.txt/>`__, 
     (or you can instead browse the latest versions of the Sphinx packages `here <https://pypi.org/>`__)
     and then install locally such as:
     ::

--- a/en/mapfile/index.txt
+++ b/en/mapfile/index.txt
@@ -11,7 +11,7 @@
 :Contact: steve.lime at dnr.state.mn.us
 :Author: Jeff McKenna
 :Contact: jmckenna at gatewaygeomatics.com
-:Last Updated: 2020-05-10
+:Last Updated: 2021-03-19
 
 The Mapfile is the heart of MapServer.  It defines the relationships
 between objects, points MapServer to where data are located and

--- a/en/mapfile/label.txt
+++ b/en/mapfile/label.txt
@@ -82,26 +82,26 @@ ANTIALIAS [true|false]
     anti-aliasing can not be turned off).
 
 BACKGROUNDCOLOR [r] [g] [b] | [hexadecimal string]
+    .. versionremoved:: 6.0  
+       Use a `LABEL STYLE`_ object with`GEOMTRANSFORM labelpoly` and `COLOR`
+       instead.
+       
     Color to draw a background rectangle (i.e. billboard). Off by default.
 
-    .. note::
-       Removed in 6.0.  Use a `LABEL STYLE`_ object with
-       `GEOMTRANSFORM labelpoly` and `COLOR`.
-
 BACKGROUNDSHADOWCOLOR [r] [g] [b] | [hexadecimal string]
+    .. versionremoved:: 6.0  
+       Use a `LABEL STYLE`_ object with `GEOMTRANSFORM labelpoly`, 
+       `COLOR` and `OFFSET` instead.
+       
     Color to draw a background rectangle (i.e. billboard) shadow. Off by
     default.
 
-    .. note::
-       Removed in 6.0.  Use a `LABEL STYLE`_ object with
-       `GEOMTRANSFORM labelpoly`, `COLOR` and `OFFSET`.
-
 BACKGROUNDSHADOWSIZE [x][y]
+    .. versionremoved:: 6.0 
+       Use a `LABEL STYLE`_ object with `GEOMTRANSFORM labelpoly`, 
+       `COLOR` and `OFFSET` instead.
+       
     How far should the background rectangle be offset? Default is 1.
-
-    .. note::
-       Removed in 6.0.  Use a `LABEL STYLE`_ object with
-       `GEOMTRANSFORM labelpoly`, `COLOR` and `OFFSET`.
 
 .. index::
    pair: LABEL; BUFFER
@@ -167,6 +167,11 @@ COLOR [r] [g] [b] | [hexadecimal string] | [attribute]
    :name: mapfile-label-encoding
 
 ENCODING [string]
+    .. versionremoved:: 7.0
+       UTF-8 is now the encoding used by MapServer, and
+       dataset encodings are handled using :ref:`LAYER` `ENCODING`
+       instead.
+         
     Supported encoding format to be used for labels.  If the format is
     not supported, the label will not be drawn.  Requires the iconv
     library (present on most systems).  The library is always detected
@@ -175,10 +180,6 @@ ENCODING [string]
     Required for displaying international characters in MapServer.
     More information can be found in the :ref:`Label Encoding document
     <encoding>`.
-
-    .. deprecated:: 7.0
-         Removed.  UTF-8 is now the encoding used by MapServer, and
-         data set encodings are handled using :ref:`LAYER` `ENCODING`.
 
 .. index::
    pair: LABEL; EXPRESSION

--- a/en/mapfile/layer.txt
+++ b/en/mapfile/layer.txt
@@ -18,6 +18,8 @@
    :name: mapfile-layer-bindvals
 
 BINDVALS
+    .. versionadded:: 6.0
+
     This keyword allows name value pairs to be created to bind variables in SQL statements.
     Variable binding prevents SQL injection by properly escaping strings and integers. 
     Applies to :ref:`PostGIS <input_postgis>` and :ref:`Oracle <oci>` connections only. 
@@ -585,10 +587,9 @@ HEADER [filename]
     Signals the start of a :ref:`JOIN` object.
 
 LABELANGLEITEM [attribute]
-    .. deprecated:: 5.0
-
-    (As of MapServer 5.0 this parameter is no longer available.  Please see
-    the :ref:`LABEL` object's ANGLE parameter)
+    .. versionremoved:: 5.0
+       Please see the :ref:`LABEL` object's ANGLE parameter instead.
+       
     For MapServer versions < 5.0, this is the item name in attribute table
     to use for class annotation angles. Values should be in degrees.
 
@@ -657,10 +658,9 @@ LABELREQUIRES [expression]
     Logical operators AND and OR can be used.
 
 LABELSIZEITEM [attribute]
-    .. deprecated:: 5.0
-
-    (As of MapServer 5.0 this parameter is no longer available.  Please see
-    the :ref:`LABEL` object's SIZE parameter)
+    .. versionremoved:: 5.0
+       Please see the :ref:`LABEL` object's SIZE parameter instead.
+       
     For MapServer versions < 5.0, this is the item name in attribute table to
     use for class annotation sizes. Values should be in pixels.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 alabaster==0.7.12
 sphinx==3.5.2
+sphinx-removed-in==0.2.1


### PR DESCRIPTION
- enable the `versionremoved` Sphinx directive, using the [sphinx-removed-in](https://pypi.org/project/sphinx-removed-in/) extension
- add styling for the new  `versionremoved` and `removed-in` directives
- update the documentation guide
- minor updates: 
  - add `versionremoved` to a few label & layer parameters
  - add `versionadded` to BINDVALS in layer, to avoid users from digging into RFC for that info