### PR TITLE
Rearrange announcements for the security advisory

### DIFF
--- a/en/announcements/2021-03-30-limit-mapfile-access.txt
+++ b/en/announcements/2021-03-30-limit-mapfile-access.txt
@@ -24,4 +24,4 @@ Relevant documentation can be found at:
 
 Please don’t hesitate to reach out with questions.
 
--MapServer :ref:`psc`
+-the MapServer :ref:`Project Steering Committee (PSC)<psc>`

--- a/en/announcements/2021-03-30-limit-mapfile-access.txt
+++ b/en/announcements/2021-03-30-limit-mapfile-access.txt
@@ -1,0 +1,27 @@
+.. _2021-03-30-limit-mapfile-access:
+
+*****************************************************************************
+Security Advisory – Limiting Mapfile Access 
+*****************************************************************************
+
+:Posted: 2021-03-30
+
+This is an important reminder that, as part of a secure deployment,
+it is important to limit MapServer CGI access to mapfiles. The MapServer
+CGI has long supported the use of environment variables as a primary
+mechanism to do this. If you haven’t implemented these controls then that
+constitutes undue risk that is easily mitigated and we strongly encourage
+you to do so as soon as possible. It’s also a great time to review those
+settings if you already have them in place as we’ve recently updated regex
+examples related to *MS_MAP_PATTERN* to limit path traversal.
+
+
+
+Relevant documentation can be found at:
+
+   - :ref:`limit_mapfile_access`
+   - :ref:`environment_variables`
+
+Please don’t hesitate to reach out with questions.
+
+-MapServer :ref:`psc`

--- a/en/announcements/announcements_archive.txt
+++ b/en/announcements/announcements_archive.txt
@@ -1,9 +1,7 @@
-:orphan:
-
-.. _Announcements:
+.. _announcement_archives:
 
 *****************************************************************************
- MapServer Announcements
+ MapServer Announcement Archives
 *****************************************************************************
 
 **2020-12-07 - MapServer 7.6.2 is released**

--- a/en/announcements/index.txt
+++ b/en/announcements/index.txt
@@ -1,0 +1,13 @@
+:orphan:
+
+.. _Announcements:
+
+*****************************************************************************
+ MapServer Announcements
+*****************************************************************************
+
+.. toctree::
+   :maxdepth: 1
+
+   2021-03-30-limit-mapfile-access
+   announcements_archive

--- a/en/include/announcements.inc
+++ b/en/include/announcements.inc
@@ -1,3 +1,10 @@
+.. warning::
+    **2021-03-30 - Security Advisory – Limiting Mapfile Access**
+
+    It is important to limit MapServer CGI access to mapfiles, to 
+    prevent malicious attacks to your file system.  Please see details 
+    in the announcement at :ref:`2021-03-30-limit-mapfile-access`.
+
 **2020-12-07 - MapServer 7.6.2 is released**
 
 The maintenance release of MapServer 7.6.2 is now available.


### PR DESCRIPTION
- new directory: /announcements/
- will hold pointers to all announcements (advisories, sprints, events, etc)
- advisory file will be timestamped (YYYY-MM-DD-name.txt)