### PR TITLE
update for removal of LAYER DUMP in the 8.0 release

### DIFF
--- a/en/basemaps/install.txt
+++ b/en/basemaps/install.txt
@@ -119,7 +119,7 @@ Project deployment
 .. code-block:: bash
 
    $ cd  /var/www/somewhere/
-   $ git clone git@github.com:mapserver/basemaps.git
+   $ git clone git@github.com:MapServer/basemaps.git
    $ cd basemaps
 
 That's easy enough to not need much explanation.

--- a/en/basemaps/style.txt
+++ b/en/basemaps/style.txt
@@ -11,9 +11,9 @@ Tweaking Map Styles
    :backlinks: top
 
 This page contains information about the way to tweak map styles using the
-mapserver/basemaps project.
+MapServer/basemaps project.
 
-Prior to using this version of mapserver/basemaps, you have to import OSM map
+Prior to using this version of MapServer/basemaps, you have to import OSM map
 data into a postgis database using the imposm tool. See :ref:`basemaps_install`
 to know how to set up easily your project.
 

--- a/en/cgi/controls.txt
+++ b/en/cgi/controls.txt
@@ -602,7 +602,7 @@ Apache variables can be used to specify the location of map files
 
           SetEnv MY_MAPFILE "/opt/mapserver/map1/mymapfile.map"
 
-2. Refer to the variable in the mapserver CGI URL:
+2. Refer to the variable in the MapServer CGI URL:
 
    ::
 
@@ -628,7 +628,7 @@ application in the order identified below.
 
 INPUT_TYPE (auto_rect | auto_point)
     The INPUT_TYPE parameter is needed to identify if the coordinates handed
-    over to the mapserver have to be interpreted as rectangular or point data.
+    over to the MapServer have to be interpreted as rectangular or point data.
 
 INPUT_COORD [minx,miny;maxx,maxy]
     The ROSA-Applet always fills the pair of coordinates. In case of a point

--- a/en/cgi/controls.txt
+++ b/en/cgi/controls.txt
@@ -628,7 +628,7 @@ application in the order identified below.
 
 INPUT_TYPE (auto_rect | auto_point)
     The INPUT_TYPE parameter is needed to identify if the coordinates handed
-    over to the MapServer have to be interpreted as rectangular or point data.
+    over to MapServer have to be interpreted as rectangular or point data.
 
 INPUT_COORD [minx,miny;maxx,maxy]
     The ROSA-Applet always fills the pair of coordinates. In case of a point

--- a/en/input/raster.txt
+++ b/en/input/raster.txt
@@ -890,7 +890,7 @@ Note that overview building should be done after translating to a
 final format.  Overviews are lost in format conversions using
 gdal_translate.  Also, nothing special needs to be done to make
 MapServer use GDAL generated overviews.  They are automatically picked
-up by GDAL when mapserver requests a reduced resolution map.
+up by GDAL when MapServer requests a reduced resolution map.
 
 
 .. index::

--- a/en/installation/unix.txt
+++ b/en/installation/unix.txt
@@ -97,7 +97,7 @@ environment variables to secure your server are listed in :ref:`environment_vari
         producing (i.e. writing) images.
   
 * `zlib`_: Zlib should be on your system by default.  Though not used
-  directly by mapserver, it's a mandatory dependency of libpng.
+  directly by MapServer, it's a mandatory dependency of libpng.
 
 -----------------------------------------------------------------------------
  Highly Recommended Libraries
@@ -221,7 +221,7 @@ More information on using this feature is available in :ref:`wms_server`.
 
 WMS Client
 -------------------
-Cascading is also supported. This allows mapserver to transparently 
+Cascading is also supported. This allows MapServer to transparently 
 fetch remote layers over WMS, basically acting like a client, and combine 
 them with other layers to generate the final map.
 
@@ -321,7 +321,7 @@ MapServer can use a wide variety of sources of data input. One of the
 solutions growing in popularity is to use spatially enabled databases to 
 store data, and to use them directly to draw maps for the web.
 
-Here you will find out how to enable mapserver to talk to one of these 
+Here you will find out how to enable MapServer to talk to one of these 
 products. Please refer to the MapFile reference for more details on how to 
 use these. This section only details how to compile MapServer for their use.
 
@@ -397,7 +397,7 @@ usually use:
    Oracle Spatial, AGG, Ming, PDFlib, or MyGIS.  Mix and match as you need
    them.
 
-5. Unpack the MapServer tarball and cd into the mapserver directory::
+5. Unpack the MapServer tarball and cd into the MapServer directory::
    
       $ tar -zxvf mapserver-X.Y.Z.tar.gz
 
@@ -449,7 +449,7 @@ usually use:
    record of how MapServer was configured.                      
 
 7. Now that you have configured your build options and selected all the 
-   libraries you wish mapserver to use, you're ready to compile the 
+   libraries you wish MapServer to use, you're ready to compile the 
    source code.
    
    This is actually quite simple, just execute "make"::

--- a/en/installation/v8.txt
+++ b/en/installation/v8.txt
@@ -85,7 +85,7 @@ Compile MapServer with V8 Support
 
 ::
 
-    cd mapserver
+    cd MapServer
     mkdir build
     cd build
     cmake -DCMAKE_PREFIX_PATH=/opt/v8 -DWITH_V8=yes ..

--- a/en/installation/win32.txt
+++ b/en/installation/win32.txt
@@ -266,7 +266,7 @@ and update the PROJ_DIR path to point to your PROJ build.
 :: 
   
   # Reprojecting.
-  # If you would like mapserver to be able to reproject data from one
+  # If you would like MapServer to be able to reproject data from one
   # geographic projection to another, uncomment the following flag
   # PROJ distribution (cartographic projection routines).  PROJ is
   # also required for all OGC services (WMS, WFS, and WCS). 
@@ -365,12 +365,12 @@ vcvars32.bat usually located in **C:\Program Files\Microsoft Visual Studio\VC98\
 
 :: 
   
-  C:\Users> cd \projects\mapserver
-  C:\Projects\mapserver&> C:\Program Files\Microsoft Visual Studio\VC98\Bin\vcvars32.bat"
-  C:\Projects\mapserver>
+  C:\Users> cd \projects\MapServer
+  C:\Projects\MapServer&> C:\Program Files\Microsoft Visual Studio\VC98\Bin\vcvars32.bat"
+  C:\Projects\MapServer>
   
   Setting environment for using Microsoft Visual C++ tool.
-  C:\Projects\mapserver>
+  C:\Projects\MapServer>
 
 Now issue the command: **nmake /f Makefile.vc** and wait 
 for it to finish compiling. If it compiles successfully, you should get 
@@ -412,7 +412,7 @@ MapServer.
  * Visual C++ Tools Not Properly Initialized.
    :: 
    
-    C:\projects\mapserver> nmake -f /makefile.vc
+    C:\projects\MapServer> nmake -f /makefile.vc
     'nmake' is not recognized as an internal or external command,
     operable program or batch file.
 

--- a/en/mapfile/expressions.txt
+++ b/en/mapfile/expressions.txt
@@ -328,7 +328,7 @@ List expressions
 
 List expressions (see :ref:`rfc95`) are a performant way to compare a
 string attribute to a list of multiple possible values. Their behavior
-duplicates the existing regex or mapserver expressions, however they are
+duplicates the existing regex or MapServer expressions, however they are
 significantly more performant. To activate them enclose a comma separated
 list of values between {}, **without** adding quotes or extra spaces.
 
@@ -342,7 +342,7 @@ list of values between {}, **without** adding quotes or extra spaces.
         CLASS
           EXPRESSION {motorway,trunk}
           #equivalent to regex EXPRESSION /motorway|trunk/
-          #equivalent to mapserver EXPRESSION ("[roadtype]" IN "motorway,trunk")
+          #equivalent to MapServer EXPRESSION ("[roadtype]" IN "motorway,trunk")
           ...
         END
         CLASS

--- a/en/mapfile/layer.txt
+++ b/en/mapfile/layer.txt
@@ -673,7 +673,7 @@ MASK [layername]
     The data from the current layer will only be rendered where it intersects
     features from the [layername] layer. [layername] must reference the NAME of
     another LAYER_ defined in the current mapfile. can be any kind of
-    mapserver layer, i.e. vector or raster. If the current layer has labelling
+    MapServer layer, i.e. vector or raster. If the current layer has labelling
     configured, then only labels who's label-point fall inside the unmasked
     area will be added to the labelcache (the actual glyphs for the label
     may be rendered ontop of the masked-out area.

--- a/en/mapfile/layer.txt
+++ b/en/mapfile/layer.txt
@@ -339,7 +339,8 @@ DEBUG [off|on|0|1|2|3|4|5]
    :name: mapfile-layer-dump
 
 DUMP [true|false]
-    .. deprecated:: 6.0 use `LAYER` `METADATA` instead.
+    .. versionremoved:: 8.0 
+       Please use *LAYER* *METADATA* instead.
 
     Switch to allow MapServer to return data in GML format. Useful when
     used with WMS GetFeatureInfo operations. "false" by default.

--- a/en/mapscript/mapscript.txt
+++ b/en/mapscript/mapscript.txt
@@ -20,7 +20,7 @@
 :Contact: dmorisette at mapgears.com
 :Author: Jeff McKenna
 :Contact: jmckenna at gatewaygeomatics.com
-:Last Updated: 2020-04-29
+:Last Updated: 2021-04-06
 
  .. note::
 
@@ -569,11 +569,11 @@ msIO_getStdoutBufferString() : string
   not clear the buffer.
 
 msIO_installStdinFromBuffer() : void
-  Installs a mapserver IO handler directing future stdin reading (ie. post 
+  Installs a MapServer IO handler directing future stdin reading (ie. post 
   request capture) to come from a buffer. 
 
 msIO_installStdoutToBuffer() : void
-  Installs a mapserver IO handler directing future stdout output to a memory
+  Installs a MapServer IO handler directing future stdout output to a memory
   buffer. 
 
 msIO_resetHandlers() : void
@@ -1204,7 +1204,7 @@ autoangle : int
     MS_TRUE or MS_FALSE
     
 autofollow : int
-    MS_TRUE or MS_FALSE. Tells mapserver to compute a curved label
+    MS_TRUE or MS_FALSE. Tells MapServer to compute a curved label
     for appropriate linear features (see :ref:`rfc11` for specifics).   
 
 autominfeaturesize: int
@@ -1419,12 +1419,11 @@ debug : int
         :ref:`debugging`
     
 dump : int
-    .. deprecated:: 6.0 use metadata instead.
+    .. deprecated:: 8.0
+       Please use *LAYER* *METADATA* instead (DUMP was initially deprecated for the 6.0
+       release, and formally removed for the 8.0 release).
 
-    Since 6.0, `dump` is not available anymore.
-    Use metadata is instead.
-
-    Switch to allow mapserver to return data in GML format.  MS_TRUE or
+    Switch to allow MapServer to return data in GML format.  MS_TRUE or
     MS_FALSE.  Default is MS_FALSE.
 
 extent : rectObj_
@@ -1850,7 +1849,7 @@ setConnectionType(int connectiontype, string library_str) : int
     instead of setting the connectiontype parameter directly.
     In case when the layer.connectiontype = MS_PLUGIN the library_str 
     parameter should also be specified so as to select the library to load by
-    mapserver. For the other connection types this parameter is not used.
+    MapServer. For the other connection types this parameter is not used.
 
 setExtent( float minx, float miny, float maxx, float maxy ) : int
     Sets the extent of a layer.  Returns MS_SUCCESS or MS_FAILURE.

--- a/en/ogc/mapscript.txt
+++ b/en/ogc/mapscript.txt
@@ -39,7 +39,7 @@ requests for further post-processing.
 =============================================================================
 
 The following trivial example, in Python, demonstrates a script that 
-internally provides the map name, but otherwise uses normal mapserver
+internally provides the map name, but otherwise uses normal MapServer
 processing.
 
 .. code-block:: python

--- a/en/output/pdf.txt
+++ b/en/output/pdf.txt
@@ -92,7 +92,7 @@ Here are some quick notes on how to build on windows:
 
 - copy the pdflib.dll under your system directory (ex : c:/winnt/system32)
 
-- the pdflib.lib will be used while building mapserver with the PDF support
+- the pdflib.lib will be used while building MapServer with the PDF support
 
 Build MapServer with PDF support
 --------------------------------


### PR DESCRIPTION
- related to changes in https://github.com/MapServer/MapServer/pull/6264
- minor "MapServer" spelling