### PR TITLE
correct default for label partials

### DIFF
--- a/en/mapfile/label.txt
+++ b/en/mapfile/label.txt
@@ -432,9 +432,13 @@ OUTLINEWIDTH [integer]
    :name: mapfile-label-partials
 
 PARTIALS [true|false]
-    Can text run off the edge of the map? Default is true.  If `FORCE`
+    Can text run off the edge of the map? Default is false.  If `FORCE`
     is true and `PARTIALS` is false, `FORCE` takes precedence, and
     partial labels are drawn.
+    
+    .. note::
+       The default changed from true to false, since the MapServer 7.2
+       release.
 
 .. index::
    pair: LABEL; POSITION


### PR DESCRIPTION
- caught through https://github.com/MapServer/MapServer/issues/6334 by @mrclBIE 
- initially implemented in the source code for the MapServer 7.2 release through https://github.com/MapServer/MapServer/issues/5198