### PR TITLE
correct default label partials

### DIFF
--- a/en/mapscript/mapscript.txt
+++ b/en/mapscript/mapscript.txt
@@ -20,7 +20,7 @@
 :Contact: dmorisette at mapgears.com
 :Author: Jeff McKenna
 :Contact: jmckenna at gatewaygeomatics.com
-:Last Updated: 2021-04-06
+:Last Updated: 2021-05-21
 
  .. note::
 
@@ -1279,8 +1279,12 @@ outlinecolor : colorObj_
     Color of one point outline.
 
 partials : int
-    MS_TRUE (default) or MS_FALSE.  Whether or not labels can flow past
+    MS_TRUE or MS_FALSE (default).  Whether or not labels can flow past
     the map edges.
+    
+    .. note::
+       The default changed from true to false, since the MapServer 7.2
+       release.
     
 position : int
     MS_UL, MS_UC, MS_UR, MS_CL, MS_CC, MS_CR, MS_LL, MS_LC, MS_LR, or


### PR DESCRIPTION
- also correct in the SWIG documentation