### PR TITLE
MapCache: correct seeder usage for scanline/iteration-mode

### DIFF
--- a/en/mapcache/seed.txt
+++ b/en/mapcache/seed.txt
@@ -45,9 +45,10 @@ tileset must reference the given grid).
 
 **-h | --help**: show help.
 
-**-i | --iteration-mode**: either "*drill-down*" or "*level-by-level*".
+**-i | --iteration-mode**: either "*drill-down*" or "*scanline*".
 Default is to use drill-down for g, WGS84 and GoogleMapsCompatible grids, and
-level-by-level for others. Use this flag to override.
+scanline for others. Use this flag to override. (scanline was formerly 
+referred to as "level-by-level")
 
 **-m | --mode**: the mode to use the seeder: "*seed*", "*delete*" or
 "*transfer*".


### PR DESCRIPTION
- mapcache_seed utility mentions 'scanline" as option for iteration-mode (but docs say "level-by-level")