### PR TITLE
update for CVE map path access

### DIFF
--- a/en/development/changelog/changelog-7-0.txt
+++ b/en/development/changelog/changelog-7-0.txt
@@ -12,7 +12,7 @@ file from the source directory.
 Changes from 7.0.7 to 7.0.8
 ===========================
 
-* Security: Address flaw in CGI mapfile loading that makes it possible to bypass security controls ( `#6313 <https://github.com/mapserver/mapserver/issues/6313>`__ ) ( `#6314 <https://github.com/mapserver/mapserver/issues/6314>`__ ) (Steve Lime) : `82a3eb5 <https://github.com/mapserver/mapserver/commit/82a3eb5f6c8f75cedd095b909cc4990f3d8a99e1>`__
+* CVE-2021-32062: Address flaw in CGI mapfile loading that makes it possible to bypass security controls ( `#6313 <https://github.com/mapserver/mapserver/issues/6313>`__ ) ( `#6314 <https://github.com/mapserver/mapserver/issues/6314>`__ ) (Steve Lime) : `82a3eb5 <https://github.com/mapserver/mapserver/commit/82a3eb5f6c8f75cedd095b909cc4990f3d8a99e1>`__
 * Use CPLSetConfigOption/CPLGetConfigOption for some CGI/FastCGI-related env vars ( `#6305 <https://github.com/mapserver/mapserver/issues/6305>`__ ) (Seth G) : `3c3c9b3 <https://github.com/mapserver/mapserver/commit/3c3c9b3934f42808c15957f9378dec904203228d>`__
 * handle phpmapscript vulnerability in error handling ( `#6014 <https://github.com/mapserver/mapserver/issues/6014>`__ ) (Jeff McKenna) : `7e36981 <https://github.com/mapserver/mapserver/commit/7e36981948cb3a304f17256f0ea051e5c32d330f>`__
 * Fix potential XSS issue with [layers] tag. (Steve Lime) : `7d75e8f <https://github.com/mapserver/mapserver/commit/7d75e8f9c4acc7337f2b128a23a27eac752d846a>`__

--- a/en/development/changelog/changelog-7-2.txt
+++ b/en/development/changelog/changelog-7-2.txt
@@ -12,7 +12,7 @@ file from the source directory.
 Changes from 7.2.2 to 7.2.3
 ===========================
 
-* Security: Address flaw in CGI mapfile loading that makes it possible to bypass security controls ( `#6313 <https://github.com/mapserver/mapserver/issues/6313>`__ ) ( `#6314 <https://github.com/mapserver/mapserver/issues/6314>`__ ) (Steve Lime) : `7db7cbb <https://github.com/mapserver/mapserver/commit/7db7cbb26b6bc6e651db268e9536836a56e6825a>`__
+* CVE-2021-32062: Address flaw in CGI mapfile loading that makes it possible to bypass security controls ( `#6313 <https://github.com/mapserver/mapserver/issues/6313>`__ ) ( `#6314 <https://github.com/mapserver/mapserver/issues/6314>`__ ) (Steve Lime) : `7db7cbb <https://github.com/mapserver/mapserver/commit/7db7cbb26b6bc6e651db268e9536836a56e6825a>`__
 * Use CPLSetConfigOption/CPLGetConfigOption for some CGI/FastCGI-related env vars ( `#6305 <https://github.com/mapserver/mapserver/issues/6305>`__ ) (Seth G) : `c079fb1 <https://github.com/mapserver/mapserver/commit/c079fb110b335d0ece78049ba7bc5d1d67023003>`__
 * handle PHPMapScript vulnerability in error handling ( `#6014 <https://github.com/mapserver/mapserver/issues/6014>`__ ) (Jeff McKenna) : `1ce0d4d <https://github.com/mapserver/mapserver/commit/1ce0d4dc7e4f3f7e503f6499e14d2bd74e62ce4d>`__
 * Fix potential XSS issue with [layers] tag. (Steve Lime) : `fe08631 <https://github.com/mapserver/mapserver/commit/fe08631bcdf54ada918cda22214aa2b5a6ec19cb>`__

--- a/en/development/changelog/changelog-7-4.txt
+++ b/en/development/changelog/changelog-7-4.txt
@@ -12,7 +12,7 @@ file from the source directory.
 Changes from 7.4.4 to 7.4.5
 ===========================
 
-* Security: Address flaw in CGI mapfile loading that makes it possible to bypass security controls ( `#6313 <https://github.com/mapserver/mapserver/issues/6313>`__ ) ( `#6314 <https://github.com/mapserver/mapserver/issues/6314>`__ ) (Steve Lime) : `d611782 <https://github.com/mapserver/mapserver/commit/d6117828a160feed354bce90e5ddb2874f0e306f>`__
+* CVE-2021-32062: Address flaw in CGI mapfile loading that makes it possible to bypass security controls ( `#6313 <https://github.com/mapserver/mapserver/issues/6313>`__ ) ( `#6314 <https://github.com/mapserver/mapserver/issues/6314>`__ ) (Steve Lime) : `d611782 <https://github.com/mapserver/mapserver/commit/d6117828a160feed354bce90e5ddb2874f0e306f>`__
 * Use CPLSetConfigOption/CPLGetConfigOption for some CGI/FastCGI-related env vars ( `#6305 <https://github.com/mapserver/mapserver/issues/6305>`__ ) (Seth G) : `f19c8b7 <https://github.com/mapserver/mapserver/commit/f19c8b7a615fefd751056b8c1d3749f9ff31ff10>`__
 * WCS 1.1 and 2.0: fix support of netCDF output (complementary fix to refs  `#5968 <https://github.com/mapserver/mapserver/issues/5968>`__ ) (Even Rouault) : `6bd9301 <https://github.com/mapserver/mapserver/commit/6bd9301b6204043773ed904ced606a83659c9ca9>`__
 

--- a/en/development/changelog/changelog-7-6.txt
+++ b/en/development/changelog/changelog-7-6.txt
@@ -12,7 +12,7 @@ file from the source directory.
 Changes from 7.6.2 to 7.6.3
 ===========================
 
-* Security: Address flaw in CGI mapfile loading that makes it possible to bypass security controls ( `#6313 <https://github.com/mapserver/mapserver/issues/6313>`__ ) ( `#6314 <https://github.com/mapserver/mapserver/issues/6314>`__ ) ( `#6315 <https://github.com/mapserver/mapserver/issues/6315>`__ ) (Even Rouault) : `927ac97 <https://github.com/mapserver/mapserver/commit/927ac97cb9ece305306b5ab2b5600d3afe8c1732>`__
+* CVE-2021-32062: Address flaw in CGI mapfile loading that makes it possible to bypass security controls ( `#6313 <https://github.com/mapserver/mapserver/issues/6313>`__ ) ( `#6314 <https://github.com/mapserver/mapserver/issues/6314>`__ ) ( `#6315 <https://github.com/mapserver/mapserver/issues/6315>`__ ) (Even Rouault) : `927ac97 <https://github.com/mapserver/mapserver/commit/927ac97cb9ece305306b5ab2b5600d3afe8c1732>`__
 * Fix most of remaining Coverity scan warnings with high priority ( `#6307 <https://github.com/mapserver/mapserver/issues/6307>`__ ) (Even Rouault) : `f89e386 <https://github.com/mapserver/mapserver/commit/f89e386ba5e1e23160d044e1f38f094b979ad303>`__
 * Use CPLSetConfigOption/CPLGetConfigOption for some CGI/FastCGI-related env vars. ( `#6304 <https://github.com/mapserver/mapserver/issues/6304>`__ ) (Steve Lime) : `b128dac <https://github.com/mapserver/mapserver/commit/b128dace3ec3e61bf063f7285d1279e9f9fd9e28>`__
 * Require url-based symbol values to be pre-defined. ( `#6301 <https://github.com/mapserver/mapserver/issues/6301>`__ ) (Steve Lime) : `3c1a5c6 <https://github.com/mapserver/mapserver/commit/3c1a5c6ca2b0180de5a777fdcee86d79f146c728>`__

--- a/en/environment_variables.txt
+++ b/en/environment_variables.txt
@@ -153,6 +153,37 @@ MS_MAPFILE_PATTERN
    The default value for this variable is::
 
      MS_MAPFILE_PATTERN='\.map$'
+     
+.. index::
+   pair: Environment variables; MS_MAP_BAD_PATTERN
+
+MS_MAP_BAD_PATTERN
+   .. versionadded:: 7.6.3
+   
+   The `MS_MAP_BAD_PATTERN` environment variable can be used to specify a
+   Regular Expression to catch & not allow problematic character sequences 
+   in any mapfile paths passed to the mapserv CGI in the map=... URL parameter.
+   If the value matches then an error is generated.  By default all 
+   MapServer installations (since 7.6.3) set a hardcoded value for 
+   *MS_MAP_BAD_PATTERN* of:
+   ::
+
+    [/\\]{2}|[/\\]?\\.+[/\\]|,
+  
+   which will therefore not allow "/../" or "//" in the map value.
+
+   For Windows users, MS4W uses the PCRE regex library (which requires a 
+   slightly different regex syntax), so all future MS4W releases will 
+   contain the following default *MS_MAP_BAD_PATTERN* enabled 
+   (to not allow "/../" or "//" in the map value) :
+   
+   ::
+   
+     [\/\\\\]{2}|[\/\\\\]?\.{2,}[\/\\\\]|,
+     
+   For more Windows information see `Securing your MS4W Installation <https://ms4w.com/README_INSTALL.html#securing-your-ms4w-installation>`_
+
+   .. seealso:: :ref:`limit_mapfile_access` & Associated `Pull Request <https://github.com/MapServer/MapServer/pull/6314>`_ for the 7.6.3 release
 
 .. index::
    pair: Environment variables; MS_MAP_PATTERN

--- a/en/include/announcements.inc
+++ b/en/include/announcements.inc
@@ -1,7 +1,7 @@
 **2021-04-30 - MapServer 7.6.3, 7.4.5, 7.2.3, and 7.0.8 are released**
 
 Several maintenance releases of MapServer have been issued in order to fix
-a security flaw for processing the MAP parameter (CVE is unassigned currently).
+a security flaw for processing the MAP parameter (`CVE-2021-32062 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32062>`_).
 See the :ref:`7.6.3 changelog <changelog-7-6-3>`,
 :ref:`7.4.5 changelog <changelog-7-4-5>`,
 :ref:`7.2.3 changelog <changelog-7-2-3>`,

--- a/en/optimization/limit_mapfile_access.txt
+++ b/en/optimization/limit_mapfile_access.txt
@@ -11,17 +11,20 @@
 :Contact: sdlime at gmail.com
 :Author: Jeff McKenna
 :Contact: jmckenna at gatewaygeomatics.com
-:Last Updated: 2021-03-31
+:Last Updated: 2021-06-03
 
 The MapServer CGI, by default, will happily attempt to process any mapfile it is 
 asked to. While this might be desireable in a development environment, it is not 
 acceptable for public-facing installations. MapServer supports the use of specific
-**environment variables**, set at the web server tier, to limit access. Use of 
-these environment variables is not required but is **strongly recommended**. 
-Future versions of MapServer will require use by default.
+**environment variables**, set at the web server tier, to limit access. Since 
+the MapServer 7.6.3 release, you are **required** to use (a combination of) 
+these environment variables to secure your installation; for earlier MapServer 
+versions these environment variables are **strongly recommended**.
 
-Relevant environment variable support is available for versions: 5.4.0 and newer, 
-5.2.2, and 4.10.4.
+.. warning:: 
+    The vulnerability `CVE-2021-32062 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32062>`_
+    was fixed through the MapServer 7.6.3 release, through requiring the use of
+    the environment variables described in this MapServer document.
 
 .. note:: 
     Environment variables are only referenced by the MapServer CGI and are not 
@@ -31,9 +34,44 @@ Key Environment Variables
 =========================
 
 .. seealso:: :ref:`environment_variables`
-.. seealso:: :ref:`rfc56` 
+.. seealso:: :ref:`rfc56`
+.. seealso:: Associated `Pull Request <https://github.com/MapServer/MapServer/pull/6314>`_ for the 7.6.3 release
+
+.. tip:: 
+    The online tools `RegExr <https://regexr.com/>`__ & `RegEx101 <https://regex101.com/>`__ 
+    are great for testing regular expressions. 
+
+**MS_MAP_BAD_PATTERN**
+
+.. versionadded:: 7.6.3
+
+If set, this environment variable is interpreted as regular expression that is used 
+to test the value of the CGI map parameter, by specifying which problematic 
+character sequences to avoid. If the value matches then an error is 
+generated.  By default all MapServer installations (since 7.6.3) set a 
+hardcoded value for *MS_MAP_BAD_PATTERN* of:
+::
+
+  [/\\]{2}|[/\\]?\\.+[/\\]|,
+  
+which will therefore not allow "/../" or "//" in the map value.
+
+.. note:: 
+    For Windows users, MS4W uses the PCRE regex library (which requires a 
+    slightly different regex syntax), so all future MS4W releases will 
+    contain the following default *MS_MAP_BAD_PATTERN* enabled 
+    (to not allow "/../" or "//" in the map value) :
+    
+    ::
+    
+      [\/\\\\]{2}|[\/\\\\]?\.{2,}[\/\\\\]|,
+      
+    For more information see `Securing your MS4W Installation <https://ms4w.com/README_INSTALL.html#securing-your-ms4w-installation>`_
+  
 
 **MS_MAP_NO_PATH**
+
+.. versionadded:: 5.4.0
 
 If set, this environment variable limits values for the CGI map parameter to a 
 curated (prepared) set of mapfiles explicitly defined by additional environment 
@@ -44,6 +82,8 @@ variables. This is the recommended way to secure mapfile access if at all possib
    setting MS_MAP_NO_PATH.
  
 **MS_MAP_PATTERN**
+
+.. versionadded:: 5.4.0
  
 If set, this environment variable is interpreted as regular expression that is used 
 to test the value of the CGI map parameter. If the value does not match then 
@@ -97,10 +137,7 @@ and version)
 
     ::
 
-      SetEnv MS_MAP_PATTERN "^(C:)?\/ms4w\/apps\/((?!\.{2})[_A-Za-z0-9\-\.]+\/{1})*([_A-Za-z0-9\-\.]+\.(map))$"
-      
-  .. tip:: 
-      The online tool `RegExr <https://regexr.com/>`__ is great for testing regular expressions.      
+      SetEnv MS_MAP_PATTERN "^(C:)?\/ms4w\/apps\/((?!\.{2})[_A-Za-z0-9\-\.]+\/{1})*([_A-Za-z0-9\-\.]+\.(map))$"     
     
 - **Nginx** - http://nginx.org/en/docs/ngx_core_module.html#env
 - **IIS** - https://docs.microsoft.com/en-us/iis/configuration/system.applicationhost/applicationpools/add/environmentvariables/


### PR DESCRIPTION
- references `CVE-2021-32062`
- documents new `MS_MAP_BAD_PATTERN` environment variable