### PR TITLE
update IRC network for build notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,6 @@ after_success:
 notifications:
   irc:
     channels:
-      - "irc.freenode.org#mapserver"
+      - "irc.libera.chat#mapserver"
     use_notice: true
 


### PR DESCRIPTION
- most communities have moved to irc.libera.chat
- recently Freenode servers & channels were reset. Future there is unknown.
