### PR TITLE
Turn nitpick back on and fix some broken refs

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -59,7 +59,9 @@ autodoc_default_options = {
 }
 
 autoclass_content = 'class'
-nitpick_ignore_regex = [('py:obj', 'mapscript.*')] # New in Sphinx version 4.1
+# new in Sphinx version 4.1 - hide erroneous warnings for mapscript generated references
+nitpick_ignore_regex = [('py:obj', 'mapscript.*'), ('py:class', '.*'), 
+                        ('py:data', '.*'), ('py:func', '.*'), ('py:attr', '.*')]
 
 
 # Add any paths that contain templates here, relative to this directory.
@@ -124,7 +126,7 @@ pygments_style = 'sphinx'
 exclude_patterns = ['.git', 'howto', 'redirection', 'users-manual', 'mapscript/mapscript-api/constants', 'mapscript/mapscript-api/mapscript']
 
 # check for broken reference targets
-nitpicky = False
+nitpicky = True
 
 # Options for HTML output
 # -----------------------

--- a/en/include/labels.inc
+++ b/en/include/labels.inc
@@ -108,7 +108,6 @@
 	mapfile_tuning                 :ref:`Mapfile <mapfile_tuning>`
 	mapinfo                        :ref:`MapInfo <mapinfo>`
 	mapscript                      :ref:`MapScript <mapscript>`
-	mapscript_introduction         :ref:`Introduction <mapscript_introduction>`
 	mapscript_ows                  :ref:`MapScript Wrappers for WxS Services <mapscript_ows>`
 	mapscript_tests                :ref:`MapScript Unit Testing <mapscript_tests>`
 	mapserv                        :ref:`mapserv <mapserv>`

--- a/en/mapfile/web.txt
+++ b/en/mapfile/web.txt
@@ -79,6 +79,10 @@ LEGENDFORMAT [mime-type]
     
         LEGENDFORMAT "image/svg+xml"     
 
+.. index::
+   pair: WEB; LOG
+   :name: mapfile-web-log
+
 LOG [filename]
     .. deprecated:: 5.0  
 

--- a/en/mapscript/imagery.txt
+++ b/en/mapscript/imagery.txt
@@ -1,7 +1,7 @@
 .. index::
    pair: MapScript; Imagery
 
-.. ms_imagery:
+.. _ms_imagery:
 
 .. currentmodule:: mapscript
 


### PR DESCRIPTION
With the update to Sphinx 4.1the [nitpick_ignore_regex](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-nitpick_ignore_regex) option is available. This can filter out erroneous warnings from the MapScript Pyhon API docs (see #544). 

The `nitpick` option can be turned back on to check for broken references. 
In addition the pull request fixes a couple of broken references
