### PR TITLE
Generate GitHub pages from main branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ after_success:
   - echo "$TRAVIS_SECURE_ENV_VARS"
   - touch ./build/html/.nojekyll
   #- sh -c 'if test "$TRAVIS_SECURE_ENV_VARS" = "true" -a "$TRAVIS_BRANCH" = "branch-7-6"; then echo "publish website"; ./scripts/travis_add_deploy_key.sh; ./scripts/travis_deploy_website.sh build /tmp; fi'
+  - sh -c 'if test "$TRAVIS_SECURE_ENV_VARS" = "true" -a "$TRAVIS_BRANCH" = "main"; then echo "update GitHub pages"; ./scripts/travis_add_deploy_key.sh; ./scripts/travis_update_pages.sh $TRAVIS_BUILD_DIR/build /tmp; fi'
 
 notifications:
   irc:

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ BUILD_LANGUAGES = $(TRANSLATIONS)
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees/$$lang $(SPHINXOPTS) -c . -A language=$$lang -D language=$$lang -A languages='$(LANGUAGES)'
+ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees/$$lang $(SPHINXOPTS) -c . -A language=$$lang -D language=$$lang -A languages='$(LANGUAGES)' -A branch=$(BRANCH)
 
 ALLSPHINXOPTSI18N = $(SPHINXOPTS) -c . -a -A language=$$lang -D language=$$lang -A languages='$(LANGUAGES)'
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ BUILD_LANGUAGES = $(TRANSLATIONS)
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees/$$lang $(SPHINXOPTS) -c . -A language=$$lang -D language=$$lang -A languages='$(LANGUAGES)' -A branch=$(BRANCH)
+ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees/$$lang $(SPHINXOPTS) -c . -A language=$$lang -D language=$$lang -A languages='$(LANGUAGES)' -A branch=$(TRAVIS_BRANCH)
 
 ALLSPHINXOPTSI18N = $(SPHINXOPTS) -c . -a -A language=$$lang -D language=$$lang -A languages='$(LANGUAGES)'
 

--- a/_static/ribbon.css
+++ b/_static/ribbon.css
@@ -1,0 +1,29 @@
+.ribbon {
+  margin: 0;
+  padding: 0;
+  background: #27AE60;
+  color:white;
+  padding:1em 0;
+  position: absolute;
+  top:0;
+  right:0;
+  transform: translateX(30%) translateY(0%) rotate(45deg);
+  transform-origin: top left;
+}
+.ribbon:before,
+.ribbon:after {
+  content: '';
+  position: absolute;
+  top:0;
+  margin: 0 -1px;
+  width: 100%;
+  height: 100%;
+  background: #27AE60;
+}
+.ribbon:before {
+  right:100%;
+}
+
+.ribbon:after {
+  left:100%;
+}

--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -1,8 +1,9 @@
 {% extends "!layout.html" %}
 
-
-
 {% block relbar1 %}
+
+<!-- for main branch only, do not backport this -->
+<h4 class="ribbon">DOCS PREVIEW</h4>
 
 <table width="100%" style="width: 100%; background-color: white;">
   <tr>

--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -2,8 +2,11 @@
 
 {% block relbar1 %}
 
+
 <!-- for main branch only, do not backport this -->
+{%- if branch == 'main' %}
 <h4 class="ribbon">DOCS PREVIEW</h4>
+{%- endif %}
 
 <table width="100%" style="width: 100%; background-color: white;">
   <tr>

--- a/conf.py
+++ b/conf.py
@@ -161,6 +161,10 @@ html_static_path = ['_static']
 # using the given strftime format.
 html_last_updated_fmt = '%Y-%m-%d'
 
+html_css_files = [
+    'ribbon.css'
+]
+
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.
 html_use_smartypants = True

--- a/conf.py
+++ b/conf.py
@@ -220,6 +220,10 @@ html_show_sourcelink = False
 # Set the theme explicitly
 html_theme = "classic"
 
+# Add the branch name as a variable that can be used in templates
+# this can be set as a sphinx-build option using `-A BRANCH=main`
+html_context = {'branch': release}
+
 # Options for LaTeX output
 # ------------------------
 

--- a/scripts/travis_deploy_website.sh
+++ b/scripts/travis_deploy_website.sh
@@ -25,6 +25,5 @@ git config user.name "MapServer deploybot"
 #rm -rf .doctrees */.doctrees */.buildinfo
 
 git add -A
-git commit -m "update with results of commit https://github.com/mapserver/docs/commit/$TRAVIS_COMMIT"
+git commit -m "update with results of commit https://github.com/mapserver/MapServer-documentation/commit/$TRAVIS_COMMIT"
 git push origin master
-

--- a/scripts/travis_update_pages.sh
+++ b/scripts/travis_update_pages.sh
@@ -7,7 +7,7 @@ git config user.email "mapserverbot@mapserver.bot"
 git config user.name "MapServer deploybot"
 
 # clone without any existing files
-git clone --no-checkout --depth=1 https://mapserver:$GITHUB_TOKEN@github.com/mapserver/MapServer-documentation $destdir/MapServer-documentation
+git clone --no-checkout --depth=1 https://geographika:$GITHUB_TOKEN@github.com/geographika/MapServer-documentation $destdir/MapServer-documentation
 cd $destdir/MapServer-documentation
 git checkout -B gh-pages
 
@@ -22,5 +22,5 @@ touch .nojekyll
 
 git add -A
 git commit -m "update with results of commit https://github.com/mapserver/MapServer-documentation/commit/$TRAVIS_COMMIT" --quiet
-git remote set-url origin https://mapserver:$GITHUB_TOKEN@github.com/mapserver/MapServer-documentation
+#git remote set-url origin https://geographika:$GITHUB_TOKEN@github.com/geographika/MapServer-documentation
 git push origin gh-pages --force

--- a/scripts/travis_update_pages.sh
+++ b/scripts/travis_update_pages.sh
@@ -7,7 +7,7 @@ git config user.email "mapserverbot@mapserver.bot"
 git config user.name "MapServer deploybot"
 
 # clone without any existing files
-git clone --no-checkout --depth=1 git@github.com:mapserver/mapserver.github.io.git $destdir/MapServer-documentation
+git clone --no-checkout --depth=1 git@github.com:mapserver/MapServer-documentation.git $destdir/MapServer-documentation
 
 cd $destdir/MapServer-documentation
 git checkout -B gh-pages

--- a/scripts/travis_update_pages.sh
+++ b/scripts/travis_update_pages.sh
@@ -7,7 +7,8 @@ git config user.email "mapserverbot@mapserver.bot"
 git config user.name "MapServer deploybot"
 
 # clone without any existing files
-git clone --no-checkout --depth=1 https://geographika:$GITHUB_TOKEN@github.com/geographika/MapServer-documentation $destdir/MapServer-documentation
+git clone --no-checkout --depth=1 git@github.com:mapserver/mapserver.github.io.git $destdir/MapServer-documentation
+
 cd $destdir/MapServer-documentation
 git checkout -B gh-pages
 
@@ -22,5 +23,4 @@ touch .nojekyll
 
 git add -A
 git commit -m "update with results of commit https://github.com/mapserver/MapServer-documentation/commit/$TRAVIS_COMMIT" --quiet
-#git remote set-url origin https://geographika:$GITHUB_TOKEN@github.com/geographika/MapServer-documentation
 git push origin gh-pages --force

--- a/scripts/travis_update_pages.sh
+++ b/scripts/travis_update_pages.sh
@@ -7,7 +7,7 @@ git config user.email "mapserverbot@mapserver.bot"
 git config user.name "MapServer deploybot"
 
 # clone without any existing files
-git clone --no-checkout --depth=1 https://geographika:$GITHUB_TOKEN@github.com/geographika/MapServer-documentation $destdir/MapServer-documentation
+git clone --no-checkout --depth=1 https://mapserver:$GITHUB_TOKEN@github.com/mapserver/MapServer-documentation $destdir/MapServer-documentation
 cd $destdir/MapServer-documentation
 git checkout -B gh-pages
 
@@ -22,5 +22,5 @@ touch .nojekyll
 
 git add -A
 git commit -m "update with results of commit https://github.com/mapserver/MapServer-documentation/commit/$TRAVIS_COMMIT" --quiet
-git remote set-url origin https://geographika:$GITHUB_TOKEN@github.com/geographika/MapServer-documentation
+git remote set-url origin https://mapserver:$GITHUB_TOKEN@github.com/mapserver/MapServer-documentation
 git push origin gh-pages --force

--- a/scripts/travis_update_pages.sh
+++ b/scripts/travis_update_pages.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+builddir=$1
+destdir=$2
+
+git config user.email "mapserverbot@mapserver.bot"
+git config user.name "MapServer deploybot"
+
+# clone without any existing files
+git clone --no-checkout --depth=1 https://geographika:$GITHUB_TOKEN@github.com/geographika/MapServer-documentation $destdir/MapServer-documentation
+cd $destdir/MapServer-documentation
+git checkout -B gh-pages
+
+# delete existing files
+git rm -r * --quiet
+
+# add in the new build files
+cp -rf "$builddir/html/"* $destdir/MapServer-documentation
+
+cd $destdir/MapServer-documentation
+touch .nojekyll
+
+git add -A
+git commit -m "update with results of commit https://github.com/mapserver/MapServer-documentation/commit/$TRAVIS_COMMIT" --quiet
+git remote set-url origin https://geographika:$GITHUB_TOKEN@github.com/geographika/MapServer-documentation
+git push origin gh-pages --force


### PR DESCRIPTION
This pull request publishes any changes to the `main` branch to a new `gh-pages` branch which is then available online at https://mapserver.github.io/MapServer-documentation/

It does [not seem possible](https://github.community/t/can-i-publish-multiple-branches-of-a-repository-on-github-pages/10314/4) to publish different branches from the same repository to gh-pages, so a branch is used within `MapServer-documentation`. 

Currently the MapServer documentation workflow is to make pull requests to the "main" branch. This triggers a Sphinx build of the docs HTML output. 

This pull request then takes this output and copies it to the gh-pages branch. This is then available at https://mapserver.github.io/MapServer-documentation/ where it can be reviewed. In time it would be nice to set this up on a mapserver.org [subdomain](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/about-custom-domains-and-github-pages). 

If the update looks good (and is relevant to the current MapServer release) it can be backported to the "live" branch (currently 7-6), which continues to deploy automatically to https://mapserver.org/

If this pull request is merged then GitHub pages can be activated through Settings > Pages:

![image](https://user-images.githubusercontent.com/490840/134134148-7d3df170-70c3-4db0-ae7c-e854113ff369.png)

For testing in the https://github.com/geographika/MapServer-documentation/tree/gh-pages branch I used HTTPS to connect to GitHub rather than SSH used in `travis_deploy_website.sh` . I've switched it back for this pull request so hopefully it works as it does in the other script. 

```
# git clone --no-checkout --depth=1 https://geographika:$GITHUB_TOKEN@github.com/geographika/MapServer-documentation $destdir/MapServer-documentation
git clone --no-checkout --depth=1 git@github.com:mapserver/mapserver.github.io.git $destdir/MapServer-documentation
```

In addition a ribbonis added to the `main` (development) docs output to make it clear they are not the user docs (as discussed at https://lists.osgeo.org/pipermail/mapserver-dev/2021-September/016618.html).  

![image](https://user-images.githubusercontent.com/490840/135335023-75a4d10c-000f-4cb3-8351-5dfb6f918f93.png)


