### PR TITLE
Missing autoconf in TinyOWS install instructions from stable source.

### DIFF
--- a/en/tinyows/serverinstallation.txt
+++ b/en/tinyows/serverinstallation.txt
@@ -23,6 +23,7 @@ An example of a typical download, configure, make, make install:
     $ wget https://download.osgeo.org/mapserver/tinyows-1.2.0.tar.gz
     $ tar xzvf tinyows-1.2.0.tar.gz
     $ cd tinyows-1.2.0
+    $ autoconf
     $ ./configure
     $ make
     $ sudo make install


### PR DESCRIPTION
A small update to add the missing autoconf in TinyOWS install instructions from stable source.