### PR TITLE
add DOI badge

### DIFF
--- a/en/index.txt
+++ b/en/index.txt
@@ -21,6 +21,10 @@ and supported by developers and users from around the world.
 See the :ref:`community activities <community>` page for mailing
 lists, etc.
 
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.5842012.svg
+   :target: https://doi.org/10.5281/zenodo.5842012
+   :alt: Digital Object Identifier (DOI) for MapServer
+
 .. tip::
     Follow MapServer on `Twitter <https://twitter.com/mapserver_osgeo/>`__
 


### PR DESCRIPTION
- adds badge for the persistent (or 'concept') DOI, so we won't have to change the link for each release