### PR TITLE
Document new Mapfile validation in #6458

### DIFF
--- a/en/mapfile/class.txt
+++ b/en/mapfile/class.txt
@@ -31,7 +31,7 @@ DEBUG [on|off]
     Enables debugging of the class object. Verbose output is generated
     and sent to the standard error output (STDERR) or the MapServer
     logfile if one is set using the `LOG` parameter in the :ref:`WEB`
-    object.
+    object. Must be an integer in the range 0 to 5.
     
     .. seealso::
         
@@ -166,7 +166,7 @@ MAXSCALEDENOM [double]
     Minimum scale at which this :ref:`CLASS` is drawn. Scale is given
     as the denominator of the actual scale fraction, for example for a
     map at a scale of 1:24,000 use 24000. Implemented in MapServer
-    5.0, to replace the deprecated `MAXSCALE` parameter. Must be greater or equal to 1.
+    5.0, to replace the deprecated `MAXSCALE` parameter. Must be greater or equal to 0.
 
     .. seealso::
         
@@ -195,7 +195,7 @@ MINSCALEDENOM [double]
     Maximum scale at which this :ref:`CLASS` is drawn.  Scale is given
     as the denominator of the actual scale fraction, for example for a
     map at a scale of 1:24,000 use 24000.  Implemented in MapServer
-    5.0, to replace the deprecated `MINSCALE` parameter. Must be greater or equal to 1.
+    5.0, to replace the deprecated `MINSCALE` parameter. Must be greater or equal to 0.
     
     .. seealso::
         

--- a/en/mapfile/class.txt
+++ b/en/mapfile/class.txt
@@ -166,7 +166,7 @@ MAXSCALEDENOM [double]
     Minimum scale at which this :ref:`CLASS` is drawn. Scale is given
     as the denominator of the actual scale fraction, for example for a
     map at a scale of 1:24,000 use 24000. Implemented in MapServer
-    5.0, to replace the deprecated `MAXSCALE` parameter.
+    5.0, to replace the deprecated `MAXSCALE` parameter. Must be greater or equal to 1.
 
     .. seealso::
         
@@ -195,7 +195,7 @@ MINSCALEDENOM [double]
     Maximum scale at which this :ref:`CLASS` is drawn.  Scale is given
     as the denominator of the actual scale fraction, for example for a
     map at a scale of 1:24,000 use 24000.  Implemented in MapServer
-    5.0, to replace the deprecated `MINSCALE` parameter.
+    5.0, to replace the deprecated `MINSCALE` parameter. Must be greater or equal to 1.
     
     .. seealso::
         
@@ -206,7 +206,8 @@ MINSCALEDENOM [double]
    :name: mapfile-class-minfeaturesize
 
 MINFEATURESIZE [integer]
-    Minimum feature size (in pixels) at which a feature should be rendered. 
+    Minimum feature size (in pixels) at which a feature should be rendered.
+    Must be greater than 0.
 
 .. index::
    pair: CLASS; MINSIZE

--- a/en/mapfile/cluster.txt
+++ b/en/mapfile/cluster.txt
@@ -36,7 +36,7 @@ Mapfile Parameters
     
 MAXDISTANCE [double]
     Specifies the distance of the search region (rectangle or ellipse)
-    in pixel positions.
+    in pixel positions. Must be greater than 0.
   
 .. index::
    pair: CLUSTER; REGION

--- a/en/mapfile/composite.txt
+++ b/en/mapfile/composite.txt
@@ -37,11 +37,11 @@ Parameters
 
 OPACITY [integer]
     Sets the opacity level (or the inability to see through the layer) of all
-    classed pixels for a given layer.  A value of 100 is opaque and 
+    classed pixels for a given layer. Must be between 0 to 100. A value of 100 is opaque and
     0 is fully transparent.
 
 .. index::
-	pair: COMPOSITE; COMPOP
+    pair: COMPOSITE; COMPOP
  :name: mapfile-composite-compop
    
 COMPOP [string]

--- a/en/mapfile/grid.txt
+++ b/en/mapfile/grid.txt
@@ -36,7 +36,7 @@ LABELFORMAT [DD|DDMM|DDMMSS|C format string]
     
 MINARCS [double]
     The minimum number of arcs to draw. Increase this parameter to get 
-    more lines. Optional.
+    more lines. Optional.  Must be greater than 0.
 
 .. index::
    pair: GRID; MAXARCS
@@ -44,7 +44,7 @@ MINARCS [double]
     
 MAXARCS [double]
     The maximum number of arcs to draw.   Decrease this parameter to 
-    get fewer lines.  Optional.
+    get fewer lines.  Optional. Must be greater than 0.
 
 .. index::
    pair: GRID; MININTERVAL
@@ -53,6 +53,7 @@ MAXARCS [double]
 MININTERVAL [double]
     The minimum number of intervals to try to use. The distance between 
     the grid lines, in the units of the grid's coordinate system.  Optional.
+    Must be greater than 0.
 
 .. index::
    pair: GRID; MAXINTERVAL
@@ -61,6 +62,7 @@ MININTERVAL [double]
 MAXINTERVAL [double]
     The maximum number of intervals to try to use.  The distance between 
     the grid lines, in the units of the grid's coordinate system.  Optional.
+    Must be greater than 0.
 
 .. index::
    pair: GRID; MINSUBDIVIDE
@@ -69,7 +71,7 @@ MAXINTERVAL [double]
 MINSUBDIVIDE [double]
     The minimum number of segments to use when rendering an arc.  If the 
     lines should be very curved, use this to smooth the lines by adding more 
-    segments.  Optional.
+    segments.  Optional. Must be greater than 0.
 
 .. index::
    pair: GRID; MAXSUBDIVIDE
@@ -78,7 +80,7 @@ MINSUBDIVIDE [double]
 MAXSUBDIVIDE [double]
     The maximum number of segments to use when rendering an arc. If the 
     graticule should be very straight, use this to minimize the number of 
-    points for faster rendering.  Optional, default 256.
+    points for faster rendering.  Optional, default 256. Must be greater than 0.
 
 Example1: Grid Displaying Degrees
 =================================

--- a/en/mapfile/label.txt
+++ b/en/mapfile/label.txt
@@ -245,7 +245,7 @@ MAXLENGTH [integer]
 
     Support for negative MAXLENGTH that implied forced linebreaks is not
     supported since version 7, a workaround implies pre-processing such labels
-    to include linebreaks or wrap characters.
+    to include linebreaks or wrap characters. Must be greater than 0.
 
 .. index::
    pair: LABEL; MAXOVERLAPANGLE
@@ -261,7 +261,7 @@ MAXOVERLAPANGLE [double]
     dealing with and their tolerance to bad overlap in labels.
     As per RFC 60, if MAXOVERLAPANGLE is set to 0, then we fall back
     on pre-6.0 behavior which was to use maxoverlapangle = 0.4*MS_PI
-    (40% of 180 degrees = 72degree).
+    (40% of 180 degrees = 72degree). Must be between 0 to 360.
 
     The associated RFC document for this feature is :ref:`RFC60`.
 
@@ -274,7 +274,7 @@ MAXSCALEDENOM [double]
 
     Minimum scale at which this :ref:`LABEL` is drawn. Scale is given
     as the denominator of the actual scale fraction, for example for a
-    map at a scale of 1:24,000 use 24000.
+    map at a scale of 1:24,000 use 24000. Must be greater or equal to 1.
 
     .. seealso::
 
@@ -287,7 +287,7 @@ MAXSCALEDENOM [double]
 MAXSIZE [double]
     Maximum font size to use when scaling text (pixels). Default is 256.
     Starting from version 5.4, the value can also be a fractional value
-    (and not only integer).
+    (and not only an integer). Must be greater than 0.
     See :ref:`LAYER` :ref:`SYMBOLSCALEDENOM <symbolscaledenom>`.
 
 .. index::
@@ -297,7 +297,7 @@ MAXSIZE [double]
 MINDISTANCE [integer]
     Minimum distance between duplicate labels. Given in pixels.
     Starting from version 7.2, the distance is calculated from the
-    label boundary. Prior versions used the label center.
+    label boundary. Prior versions used the label center. Must be greater than 0.
 
 .. index::
    pair: LABEL; MINFEATURESIZE
@@ -320,7 +320,7 @@ MINSCALEDENOM [double]
 
     Maximum scale at which this :ref:`LABEL` is drawn. Scale is given
     as the denominator of the actual scale fraction, for example for a
-    map at a scale of 1:24,000 use 24000.
+    map at a scale of 1:24,000 use 24000. Must be greater or equal to 1.
 
     .. seealso::
 
@@ -333,7 +333,7 @@ MINSCALEDENOM [double]
 MINSIZE [double]
     Minimum font size to use when scaling text (pixels). Default is 4.
     Starting from version 5.4, the value can also be a fractional value
-    (and not only integer).
+    (and not only integer). Must be greater than 0.
     See :ref:`LAYER` :ref:`SYMBOLSCALEDENOM <symbolscaledenom>`.
 
 .. index::
@@ -425,7 +425,7 @@ OUTLINEWIDTH [integer]
     renderer supports it and the text size is variable, the outline will be
     scaled proportionally to the text and the value specified as
     OUTLINEWIDTH is therefore the width at the same scale at which the
-    SIZE_ is specified.
+    SIZE_ is specified. Must be greater than 0.
 
 .. index::
    pair: LABEL; PARTIALS
@@ -492,7 +492,7 @@ REPEATDISTANCE [integer]
 
     The label will be repeated on every line of a multiline shape and
     will be repeated multiple times along a given line at an interval
-    of REPEATDISTANCE pixels.
+    of REPEATDISTANCE pixels. Must be greater than 0.
 
     The associated RFC document for this feature is :ref:`RFC57`.
 
@@ -597,7 +597,7 @@ SIZE [integer]|[tiny|small|medium|large|giant]|[attribute]|[expression]
     
     .. note::
          The SIZE value can only be an integer (not a fractional
-         value), because the renderer Freetype only accepts integers.
+         value), because the renderer Freetype only accepts integers. Must be greater than 0.
 
 .. index::
    pair: LABEL; STYLE

--- a/en/mapfile/label.txt
+++ b/en/mapfile/label.txt
@@ -39,7 +39,7 @@ ALIGN [left|center|right|attribute]
 
 ANGLE [double|auto|auto2|follow|attribute]
     - Angle, counterclockwise, given in degrees, to draw the label.
-      Default is 0.
+      Default is 0, and must be in the range -360 to 360.
     - AUTO allows MapServer to compute the angle. Valid for LINE
       layers only.
     - AUTO2 same as AUTO, except no logic is applied to try to keep
@@ -274,7 +274,7 @@ MAXSCALEDENOM [double]
 
     Minimum scale at which this :ref:`LABEL` is drawn. Scale is given
     as the denominator of the actual scale fraction, for example for a
-    map at a scale of 1:24,000 use 24000. Must be greater or equal to 1.
+    map at a scale of 1:24,000 use 24000. Must be greater or equal to 0.
 
     .. seealso::
 
@@ -309,7 +309,7 @@ MINFEATURESIZE [integer|auto]
     polygons features the smallest dimension of the bounding box is
     used. "Auto" keyword tells MapServer to only label features that
     are larger than their corresponding label. Available for cached
-    labels only.
+    labels only. Must be greater than 0.
 
 .. index::
    pair: LABEL; MINSCALEDENOM
@@ -320,7 +320,7 @@ MINSCALEDENOM [double]
 
     Maximum scale at which this :ref:`LABEL` is drawn. Scale is given
     as the denominator of the actual scale fraction, for example for a
-    map at a scale of 1:24,000 use 24000. Must be greater or equal to 1.
+    map at a scale of 1:24,000 use 24000. Must be greater or equal to 0.
 
     .. seealso::
 

--- a/en/mapfile/layer.txt
+++ b/en/mapfile/layer.txt
@@ -619,7 +619,7 @@ LABELMAXSCALEDENOM [double]
     Minimum scale at which this LAYER is labeled.  Scale is given as the
     denominator of the actual scale fraction, for example for a map at a scale
     of 1:24,000 use 24000.  Implemented in MapServer 5.0, to replace the
-    deprecated LABELMAXSCALE parameter.
+    deprecated LABELMAXSCALE parameter. Must be greater or equal to 1.
 
     .. seealso::
 
@@ -633,7 +633,7 @@ LABELMINSCALEDENOM [double]
     Maximum scale at which this LAYER is labeled.  Scale is given as the
     denominator of the actual scale fraction, for example for a map at a scale
     of 1:24,000 use 24000.  Implemented in MapServer 5.0, to replace the
-    deprecated LABELMINSCALE parameter.
+    deprecated LABELMINSCALE parameter. Must be greater or equal to 1.
 
     .. seealso::
 
@@ -694,7 +694,7 @@ MASK [layername]
 MAXFEATURES [integer]
     Specifies the number of features that should be drawn for this layer in
     the CURRENT window. Has some interesting uses with annotation and with
-    sorted data (i.e. lakes by area).
+    sorted data (i.e. lakes by area). Must be greater than 0.
 
 .. index::
    pair: LAYER; MAXGEOWIDTH
@@ -705,7 +705,7 @@ MAXGEOWIDTH [double]
 
     Maximum width, in the map's geographic units, at which this LAYER
     is drawn.  If MAXSCALEDENOM is also specified then MAXSCALEDENOM
-    will be used instead.
+    will be used instead. Must be greater than 0.
 
     The width of a map in geographic units can be found by calculating the
     following from the extents::
@@ -722,7 +722,7 @@ MAXSCALEDENOM [double]
      
     Minimum scale at which this LAYER is drawn.  Scale is given as the
     denominator of the actual scale fraction, for example for a map at a scale
-    of 1:24,000 use 24000.
+    of 1:24,000 use 24000. Must be greater or equal to 1.
 
     .. seealso::
 
@@ -748,6 +748,14 @@ METADATA
         END
 
 .. index::
+   pair: LAYER; MINFEATURESIZE
+   :name: mapfile-layer-minfeaturesize
+
+MINFEATURESIZE [integer]
+    Minimum feature size (in pixels) for shapes in the layer.
+    Must be greater than 0.
+
+.. index::
     pair: LAYER; MINGEOWIDTH
     :name: mapfile-layer-mingeowidth
 
@@ -756,7 +764,7 @@ MINGEOWIDTH [double]
 
     Minimum width, in the map's geographic units, at which this LAYER
     is drawn.  If MINSCALEDENOM is also specified then MINSCALEDENOM
-    will be used instead.
+    will be used instead. Must be greater than 0.
 
     The width of a map in geographic units can be found by calculating the
     following from the extents::
@@ -771,7 +779,7 @@ MINSCALEDENOM [double]
     Maximum scale at which this LAYER is drawn.  Scale is given as the
     denominator of the actual scale fraction, for example for a map at a scale
     of 1:24,000 use 24000.  Implemented in MapServer 5.0, to replace the
-    deprecated MINSCALE parameter.
+    deprecated MINSCALE parameter. Must be greater or equal to 1.
 
     .. seealso::
 
@@ -1528,7 +1536,7 @@ SYMBOLSCALEDENOM [double]
     MAXSIZE as described above.  Scale is given as the denominator of
     the actual scale fraction, for example for a map at a scale of
     1:24,000 use 24000.  Implemented in MapServer 5.0, to replace the
-    deprecated SYMBOLSCALE parameter.
+    deprecated SYMBOLSCALE parameter. Must be greater or equal to 1.
 
     .. seealso::
 

--- a/en/mapfile/layer.txt
+++ b/en/mapfile/layer.txt
@@ -619,7 +619,7 @@ LABELMAXSCALEDENOM [double]
     Minimum scale at which this LAYER is labeled.  Scale is given as the
     denominator of the actual scale fraction, for example for a map at a scale
     of 1:24,000 use 24000.  Implemented in MapServer 5.0, to replace the
-    deprecated LABELMAXSCALE parameter. Must be greater or equal to 1.
+    deprecated LABELMAXSCALE parameter. Must be greater or equal to 0.
 
     .. seealso::
 
@@ -633,7 +633,7 @@ LABELMINSCALEDENOM [double]
     Maximum scale at which this LAYER is labeled.  Scale is given as the
     denominator of the actual scale fraction, for example for a map at a scale
     of 1:24,000 use 24000.  Implemented in MapServer 5.0, to replace the
-    deprecated LABELMINSCALE parameter. Must be greater or equal to 1.
+    deprecated LABELMINSCALE parameter. Must be greater or equal to 0.
 
     .. seealso::
 
@@ -722,7 +722,7 @@ MAXSCALEDENOM [double]
      
     Minimum scale at which this LAYER is drawn.  Scale is given as the
     denominator of the actual scale fraction, for example for a map at a scale
-    of 1:24,000 use 24000. Must be greater or equal to 1.
+    of 1:24,000 use 24000. Must be greater or equal to 0.
 
     .. seealso::
 
@@ -779,7 +779,7 @@ MINSCALEDENOM [double]
     Maximum scale at which this LAYER is drawn.  Scale is given as the
     denominator of the actual scale fraction, for example for a map at a scale
     of 1:24,000 use 24000.  Implemented in MapServer 5.0, to replace the
-    deprecated MINSCALE parameter. Must be greater or equal to 1.
+    deprecated MINSCALE parameter. Must be greater or equal to 0.
 
     .. seealso::
 

--- a/en/mapfile/leader.txt
+++ b/en/mapfile/leader.txt
@@ -35,7 +35,7 @@ Mapfile Parameters
 GRIDSTEP [integer]
     Specifies the number of pixels between positions that are tested for 
     a label line.  You might start with a value of 5, and increase depending
-    on performance (see example below).
+    on performance (see example below). Must be greater than 0.
   
 .. index::
    pair: LEADER; MAXDISTANCE
@@ -44,7 +44,7 @@ GRIDSTEP [integer]
 MAXDISTANCE [integer]
     Specifies the maximum distance in pixels from the normal label location that
     a leader line can be drawn.  You might start with a value of 30, and increase 
-    depending on the resulting placement (see example below).
+    depending on the resulting placement (see example below). Must be greater than 0.
     
 :ref:`STYLE`
     Signals the start of a :ref:`STYLE` object.  Use this to style the leader

--- a/en/mapfile/legend.txt
+++ b/en/mapfile/legend.txt
@@ -51,7 +51,8 @@ INTERLACE [on|off]
    :name: mapfile-legend-keysize
     
 KEYSIZE [x][y]
-    Size of symbol key boxes in pixels. Default is 20 by 10.
+    Size of symbol key boxes in pixels. Default is 20 by 10. Minimum
+    values are 5, and maximum values are 200. 
 
 .. index::
    pair: LEGEND; KEYSPACING
@@ -59,7 +60,7 @@ KEYSIZE [x][y]
     
 KEYSPACING [x][y]
     Spacing between symbol key boxes ([y]) and labels ([x]) in pixels. 
-    Default is 5 by 5.
+    Default is 5 by 5. Minimum values are 0, and maximum values are 50.
 
 .. index::
    pair: LEGEND; LABEL

--- a/en/mapfile/map.txt
+++ b/en/mapfile/map.txt
@@ -22,8 +22,8 @@
    :name: mapfile-map-angle
     
 ANGLE [double]
-   Angle, given in degrees, to rotate the map. Default is 0. The
-   rendered map will rotate in a clockwise direction. The following
+   Angle, given in degrees, to rotate the map. Default is 0, and must be in the range
+   -360 to 360. The rendered map will rotate in a clockwise direction. The following
    are important notes:
 
    - Requires a :ref:`projection` object specified at the MAP level
@@ -283,7 +283,7 @@ DEFRESOLUTION [double]
     .. versionadded:: 5.6
 
     Sets the reference resolution (pixels per inch) used for
-    symbology.  Default is 72.
+    symbology.  Default is 72. Minimum is 10 and maximum is 1000.
      
     Used to automatically scale the symbology when :ref:`RESOLUTION
     <resolution-parameter>` is changed, so the map maintains the same
@@ -405,6 +405,7 @@ MAXSIZE [integer]
     can have up to 4096 pixels in both dimensions (i.e. max of
     4096x4096).  Default is 4096 for MapServer version >= 7.0.3 
     (for earlier versions the default was 2048).
+    Must be greater or equal to 1.
 
 .. index::
    pair: MAP; NAME
@@ -449,7 +450,7 @@ NAME [name]
 .. _resolution-parameter:
 
 RESOLUTION [double] Sets the pixels per inch for output, only affects
-    scale computations.  Default is 72.
+    scale computations.  Default is 72. Minimum is 10 and maximum is 1000.
 
 .. index::
    pair: MAP; SCALEDENOM
@@ -460,7 +461,7 @@ SCALEDENOM [double]
     Scale is given as the denominator of the actual scale fraction,
     for example for a map at a scale of 1:24,000 use 24000.
     Implemented in MapServer 5.0, to replace the deprecated `SCALE`
-    parameter.
+    parameter. Must be greater or equal to 1.
     
     .. seealso::
         
@@ -487,6 +488,7 @@ SHAPEPATH [filename]
     
 SIZE [x][y]
     Size in pixels of the output image (i.e. the map).
+    Values must be less than the MAXSIZE property.
 
 .. index::
    pair: MAP; STATUS

--- a/en/mapfile/map.txt
+++ b/en/mapfile/map.txt
@@ -207,7 +207,7 @@ DATAPATTERN [regular expression]
    :name: mapfile-map-debug
     
 DEBUG [off|on|0|1|2|3|4|5]
-    Enables debugging of all of the layers in the current map. 
+    Enables debugging of all of the layers in the current map.
 
     *Debugging with MapServer versions >= 5.0:*
 
@@ -405,7 +405,7 @@ MAXSIZE [integer]
     can have up to 4096 pixels in both dimensions (i.e. max of
     4096x4096).  Default is 4096 for MapServer version >= 7.0.3 
     (for earlier versions the default was 2048).
-    Must be greater or equal to 1.
+    Must be a value greater than 0.
 
 .. index::
    pair: MAP; NAME

--- a/en/mapfile/querymap.txt
+++ b/en/mapfile/querymap.txt
@@ -43,6 +43,7 @@ COLOR [r] [g] [b] | [hexadecimal string]
 
 SIZE [x][y]
     Size of the map in pixels. Defaults to the size defined in the map object.
+    Minimum x and y values are 1, and maximum values are the same as the parent MAP MAXSIZE.
 
 .. index::
    pair: QUERYMAP; STATUS

--- a/en/mapfile/querymap.txt
+++ b/en/mapfile/querymap.txt
@@ -43,7 +43,8 @@ COLOR [r] [g] [b] | [hexadecimal string]
 
 SIZE [x][y]
     Size of the map in pixels. Defaults to the size defined in the map object.
-    Minimum x and y values are 1, and maximum values are the same as the parent MAP MAXSIZE.
+    Minimum x and y values are -1 (to allow for querymaps to be hidden),
+    and maximum values are the same as the parent MAP MAXSIZE.
 
 .. index::
    pair: QUERYMAP; STATUS

--- a/en/mapfile/reference.txt
+++ b/en/mapfile/reference.txt
@@ -66,6 +66,7 @@ IMAGE [filename]
 MARKER [integer|string]
     Defines a symbol (from the symbol file) to use when the box becomes too 
     small (see MINBOXSIZE and MAXBOXSIZE below). Uses a crosshair by default.
+    Must be greater or equal to 0.
 
 .. index::
    pair: REFERENCE; MARKERSIZE
@@ -73,6 +74,7 @@ MARKER [integer|string]
 
 MARKERSIZE [integer]
     Defines the size of the symbol to use instead of a box (see MARKER above).
+    Must be greater than 0.
 
 .. index::
    pair: REFERENCE; MINBOXSIZE
@@ -80,7 +82,7 @@ MARKERSIZE [integer]
 
 MINBOXSIZE [integer]
     If box is smaller than MINBOXSIZE (use box width or height) then use the 
-    symbol defined by MARKER and MARKERSIZE.
+    symbol defined by MARKER and MARKERSIZE. Must be greater than 0.
 
 .. index::
    pair: REFERENCE; MAXBOXSIZE
@@ -88,8 +90,8 @@ MINBOXSIZE [integer]
 
 MAXBOXSIZE [integer]
     If box is greater than MAXBOXSIZE (use box width or height) then draw 
-    nothing (Often the whole map gets covered when zoomed way out and it's 
-    perfectly obvious where you are).
+    nothing (often the whole map gets covered when zoomed way out and it's 
+    perfectly obvious where you are). Must be greater than 0.
 
 .. index::
    pair: REFERENCE; OUTLINECOLOR
@@ -127,7 +129,8 @@ OUTLINECOLOR [r] [g] [b] | [hexadecimal string]
    :name: mapfile-reference-size
 
 SIZE [x][y]
-    Size, in pixels, of the base reference image.
+    Size, in pixels, of the base reference image. These values
+    must both be 5 or greater.
 
 .. index::
    pair: REFERENCE; STATUS

--- a/en/mapfile/reference.txt
+++ b/en/mapfile/reference.txt
@@ -66,7 +66,8 @@ IMAGE [filename]
 MARKER [integer|string]
     Defines a symbol (from the symbol file) to use when the box becomes too 
     small (see MINBOXSIZE and MAXBOXSIZE below). Uses a crosshair by default.
-    Must be greater or equal to 0.
+    Must be greater or equal to 0. A value of 0 indicates the default symbol for the
+    geometry type.
 
 .. index::
    pair: REFERENCE; MARKERSIZE

--- a/en/mapfile/scalebar.txt
+++ b/en/mapfile/scalebar.txt
@@ -125,6 +125,7 @@ INTERLACE [true|false]
 
 INTERVALS [integer]
     Number of intervals to break the scalebar into. Default is 4.
+    Minimum value is 1 and maximum is 100.
 
 .. index::
     pair: SCALEBAR; LABEL
@@ -141,6 +142,8 @@ OFFSET [x] [y]
     .. versionadded:: 7.2
 
     'OFFSET' moves the scalebar closer to the center of the map.
+    Minimum value is -50 and maximum is 50. 
+
     Examples:
 
     - If `POSITION` is "LL" then "OFFSET 5 2" will shift the scalebar 2
@@ -200,6 +203,8 @@ POSTLABELCACHE [true|false]
 
 SIZE [x][y]
     Size in pixels of the scalebar. Labeling is not taken into account.
+    Minimum x (width) is 5 and minimum y (height) is 2.
+    Maximum x (width) is 1000 and maximum y (height) is 100.
 
 .. index::
    pair: SCALEBAR; STATUS

--- a/en/mapfile/style.txt
+++ b/en/mapfile/style.txt
@@ -366,7 +366,7 @@ GEOMTRANSFORM [bbox|centroid|end|labelcenter|labelpnt|labelpoly|start|vertices|<
 INITIALGAP [double]
     .. versionadded:: 6.2
 
-    `INITIALGAP` is useful for styling dashed lines.
+    `INITIALGAP` is useful for styling dashed lines. Value must be greater or equal to 0.
 
     If used with `GAP`, `INITIALGAP` specifies the distance to the
     first symbol on a styled line.
@@ -454,7 +454,7 @@ LINEJOINMAXSIZE [int]
 
     Sets the max length of the `miter` `LINEJOIN` type. The value
     represents a coefficient which multiplies a current symbol
-    size. Default is 3.  See :ref:`sym_construction` for explanation
+    size. Default is 3. Must be greater than 0. See :ref:`sym_construction` for explanation
     and examples.
 
 .. index::
@@ -466,7 +466,7 @@ MAXSCALEDENOM [double]
 
     Minimum scale at which this :ref:`STYLE` is drawn. Scale is given
     as the denominator of the actual scale fraction, for example for a
-    map at a scale of 1:24,000 use 24000.
+    map at a scale of 1:24,000 use 24000. Must be greater or equal to 1.
 
     .. seealso::
         
@@ -477,7 +477,7 @@ MAXSCALEDENOM [double]
    :name: mapfile-style-maxsize
 
 MAXSIZE [double]
-    Maximum size in pixels to draw a symbol. Default is 500.  Starting
+    Maximum size in pixels to draw a symbol. Default is 500. Must be greater than 0. Starting
     from version 5.4, the value can also be a decimal value (and not
     only integer).
     See :ref:`LAYER` :ref:`SYMBOLSCALEDENOM <symbolscaledenom>`.
@@ -487,7 +487,7 @@ MAXSIZE [double]
    :name: mapfile-style-maxwidth
 
 MAXWIDTH [double]
-    Maximum width in pixels to draw the line work. Default is 32.
+    Maximum width in pixels to draw the line work. Default is 32. Must be greater than 0.
     Starting from version 5.4, the value can also be a decimal value
     (and not only integer).
     See :ref:`LAYER` :ref:`SYMBOLSCALEDENOM <symbolscaledenom>`.
@@ -501,7 +501,7 @@ MINSCALEDENOM [double]
 
     Maximum scale at which this :ref:`STYLE` is drawn. Scale is given
     as the denominator of the actual scale fraction, for example for a
-    map at a scale of 1:24,000 use 24000.
+    map at a scale of 1:24,000 use 24000. Must be greater or equal to 1.
 
     .. seealso::
         
@@ -512,7 +512,7 @@ MINSCALEDENOM [double]
    :name: mapfile-style-minsize
 
 MINSIZE [double]
-    Minimum size in pixels to draw a symbol. Default is 0.  Starting
+    Minimum size in pixels to draw a symbol. Default is 0. Must be greater than 0. Starting
     from version 5.4, the value can also be a decimal value (and not
     only integer).
     See :ref:`LAYER` :ref:`SYMBOLSCALEDENOM <symbolscaledenom>`.
@@ -522,7 +522,7 @@ MINSIZE [double]
    :name: mapfile-style-minwidth
 
 MINWIDTH [double]
-    Minimum width in pixels to draw the line work. Default is 0.
+    Minimum width in pixels to draw the line work. Default is 0. Must be greater than 0.
     Starting from version 5.4, the value can also be a decimal value
     (and not only integer).
     See :ref:`LAYER` :ref:`SYMBOLSCALEDENOM <symbolscaledenom>`.
@@ -625,7 +625,7 @@ OUTLINECOLOR [r] [g] [b] | [hexadecimal string] | [attribute]
 OUTLINEWIDTH [double|attribute]
     .. versionadded:: 5.4
 
-    Width in pixels for the outline.  Default is 0.0.  The thickness
+    Width in pixels for the outline.  Default is 0.0. Must be greater than 0. The thickness
     of the outline will not depend on the scale.
 
 .. index::
@@ -760,7 +760,7 @@ SIZE [double|attribute]
     Default value depends on the :ref:`symbol` `TYPE`.  For `pixmap`:
     the height (in pixels) of the pixmap; for `ellipse` and `vector`:
     the maximum y value of the :ref:`symbol` `POINTS` parameter, for
-    `hatch`: 1.0, for `truetype`: 1.0.
+    `hatch`: 1.0, for `truetype`: 1.0. In all cases the value must be greater than 0.
 
     When scaling of symbols is in effect (`SYMBOLSCALEDENOM` is
     specified for the :ref:`LAYER`), `SIZE` gives the height, in layer
@@ -851,7 +851,7 @@ SYMBOL [integer|string|filename|url|attribute]
 
 WIDTH [double|attribute]
     `WIDTH` refers to the thickness of line work drawn, in layer
-    `SIZEUNITS`.  Default is 1.0.
+    `SIZEUNITS`.  Default is 1.0. Must be greater than 0.
 
     When scaling of symbols is in effect (`SYMBOLSCALEDENOM` is
     specified for the :ref:`LAYER`), `WIDTH` refers to the thickness

--- a/en/mapfile/style.txt
+++ b/en/mapfile/style.txt
@@ -466,7 +466,7 @@ MAXSCALEDENOM [double]
 
     Minimum scale at which this :ref:`STYLE` is drawn. Scale is given
     as the denominator of the actual scale fraction, for example for a
-    map at a scale of 1:24,000 use 24000. Must be greater or equal to 1.
+    map at a scale of 1:24,000 use 24000. Must be greater or equal to 0.
 
     .. seealso::
         
@@ -501,7 +501,7 @@ MINSCALEDENOM [double]
 
     Maximum scale at which this :ref:`STYLE` is drawn. Scale is given
     as the denominator of the actual scale fraction, for example for a
-    map at a scale of 1:24,000 use 24000. Must be greater or equal to 1.
+    map at a scale of 1:24,000 use 24000. Must be greater or equal to 0.
 
     .. seealso::
         
@@ -512,7 +512,7 @@ MINSCALEDENOM [double]
    :name: mapfile-style-minsize
 
 MINSIZE [double]
-    Minimum size in pixels to draw a symbol. Default is 0. Must be greater than 0. Starting
+    Minimum size in pixels to draw a symbol. Default is 0. Must be greater or equal to 0. Starting
     from version 5.4, the value can also be a decimal value (and not
     only integer).
     See :ref:`LAYER` :ref:`SYMBOLSCALEDENOM <symbolscaledenom>`.
@@ -522,7 +522,7 @@ MINSIZE [double]
    :name: mapfile-style-minwidth
 
 MINWIDTH [double]
-    Minimum width in pixels to draw the line work. Default is 0. Must be greater than 0.
+    Minimum width in pixels to draw the line work. Default is 0. Must be greater or equal to 0.
     Starting from version 5.4, the value can also be a decimal value
     (and not only integer).
     See :ref:`LAYER` :ref:`SYMBOLSCALEDENOM <symbolscaledenom>`.
@@ -625,7 +625,7 @@ OUTLINECOLOR [r] [g] [b] | [hexadecimal string] | [attribute]
 OUTLINEWIDTH [double|attribute]
     .. versionadded:: 5.4
 
-    Width in pixels for the outline.  Default is 0.0. Must be greater than 0. The thickness
+    Width in pixels for the outline.  Default is 0.0. Must be greater or equal to 0. The thickness
     of the outline will not depend on the scale.
 
 .. index::
@@ -800,7 +800,8 @@ SYMBOL [integer|string|filename|url|attribute]
     The symbol to use for rendering the features.
 
     - Integer is the index of the symbol in the symbol set, starting
-      at 1 (the 5th symbol is symbol number 5).
+      at 1 (the 5th symbol is symbol number 5). A value of 0 is the
+      default symbol for the geometry type.
 
     - String is the name of the symbol (as defined using the
       :ref:`symbol` `NAME` parameter).
@@ -851,7 +852,7 @@ SYMBOL [integer|string|filename|url|attribute]
 
 WIDTH [double|attribute]
     `WIDTH` refers to the thickness of line work drawn, in layer
-    `SIZEUNITS`.  Default is 1.0. Must be greater than 0.
+    `SIZEUNITS`.  Default is 1.0. Must be greater or equal to 0.
 
     When scaling of symbols is in effect (`SYMBOLSCALEDENOM` is
     specified for the :ref:`LAYER`), `WIDTH` refers to the thickness

--- a/en/mapfile/web.txt
+++ b/en/mapfile/web.txt
@@ -102,7 +102,7 @@ MAXSCALEDENOM [double]
     This effectively prevents user from zooming too far out.  Scale is given as
     the denominator of the actual scale fraction, for example for a map at a
     scale of 1:24,000 use 24000.  Implemented in MapServer 5.0, to replace the
-    deprecated MAXSCALE parameter.
+    deprecated MAXSCALE parameter. Must be greater than 0.
     
     .. seealso::
         
@@ -233,7 +233,7 @@ MINSCALEDENOM [double]
     scale. This effectively prevents the user from zooming in too far. 
     Scale is given as the denominator of the actual scale fraction, for example
     for a map at a scale of 1:24,000 use 24000.  Implemented in MapServer 5.0, to
-    replace the deprecated MINSCALE parameter.
+    replace the deprecated MINSCALE parameter. Must be greater than 0.
 
     .. seealso::
         

--- a/en/mapfile/web.txt
+++ b/en/mapfile/web.txt
@@ -102,7 +102,7 @@ MAXSCALEDENOM [double]
     This effectively prevents user from zooming too far out.  Scale is given as
     the denominator of the actual scale fraction, for example for a map at a
     scale of 1:24,000 use 24000.  Implemented in MapServer 5.0, to replace the
-    deprecated MAXSCALE parameter. Must be greater than 0.
+    deprecated MAXSCALE parameter. Must be greater or equal to 0.
     
     .. seealso::
         
@@ -233,7 +233,7 @@ MINSCALEDENOM [double]
     scale. This effectively prevents the user from zooming in too far. 
     Scale is given as the denominator of the actual scale fraction, for example
     for a map at a scale of 1:24,000 use 24000.  Implemented in MapServer 5.0, to
-    replace the deprecated MINSCALE parameter. Must be greater than 0.
+    replace the deprecated MINSCALE parameter. Must be greater or equal to 0.
 
     .. seealso::
         


### PR DESCRIPTION
Adds various min, max and range validation rules that are now checked when parsing a Mapfile as part of [#6458](https://github.com/MapServer/MapServer/pull/6458). 
Also adds in a missing Mapfile keyword `LAYER; MINFEATURESIZE`. 
