### PR TITLE
update for MapCache 1.12.0-rc1 release

### DIFF
--- a/en/development/changelog/mapcache/changelog-1-12.txt
+++ b/en/development/changelog/mapcache/changelog-1-12.txt
@@ -1,0 +1,57 @@
+.. _changelog-mapcache-1-12:
+
+**************************
+MapCache 1.12 Changelog
+**************************
+
+.. _changelog-mapcache-1-12-0-rc1:
+
+Changes from 1.10.0 to 1.12.0-rc1
+=====================================
+
+* Increase length of line read to handle larger AWS tokens. ( `#278 <https://github.com/mapserver/mapcache/issues/278>`__ ) (Patrick M Young) : `8b4d277 <https://github.com/mapserver/mapcache/commit/8b4d277df4f7951edd84e4fb8903dc544c3315a9>`__
+* Set rpath correctly when installing the built binaries. ( `#277 <https://github.com/mapserver/mapcache/issues/277>`__ ) (Patrick M Young) : `ecf59e4 <https://github.com/mapserver/mapcache/commit/ecf59e4e00b3a861f22ea264accd5739dab1b26c>`__
+* Add cmake/FindGDAL.cmake (copied from mapserver) ( `#276 <https://github.com/mapserver/mapcache/issues/276>`__ ) (Even Rouault) : `07bb2d2 <https://github.com/mapserver/mapcache/commit/07bb2d24a1def6f31084fe994b4275382cb3ae2b>`__
+* Switch from Travis and AppVeyor to GitHub actions ( `#274 <https://github.com/mapserver/mapcache/issues/274>`__ ) (Jérome Boué) : `483aaf8 <https://github.com/mapserver/mapcache/commit/483aaf8205114c19c7465d83d45abeded2757ffe>`__
+* Issue  `#252 <https://github.com/mapserver/mapcache/issues/252>`__ : fix SIGSEGV on <symlink_blank> without <format> (jbo-ads) : `ddbcb06 <https://github.com/mapserver/mapcache/commit/ddbcb06d0af5ce576cbc49a7b8fa4e185c81b33c>`__
+* Formatting (sethg) : `31fe060 <https://github.com/mapserver/mapcache/commit/31fe060a1103a684f9c8f4a410649bca05f8e922>`__
+* Unset Content-Length (sethg) : `eacf3c8 <https://github.com/mapserver/mapcache/commit/eacf3c8d196d1846dbc7cd012e65dfe514f0ae53>`__
+* Remove commented code (sethg) : `7842b50 <https://github.com/mapserver/mapcache/commit/7842b50ee684ff4c8178312f7dffc42b523362dc>`__
+* Avoid duplicating Content-Type header (sethg) : `77d5782 <https://github.com/mapserver/mapcache/commit/77d5782d8613f75cc0be91eb1856556863e3f0a0>`__
+* update return code (sethg) : `9d0a2f6 <https://github.com/mapserver/mapcache/commit/9d0a2f6b8f3f38b31653916a9ec873b9be8dfc36>`__
+* Remove APR builds (sethg) : `49dfe33 <https://github.com/mapserver/mapcache/commit/49dfe3380dcdcbb12fa7aa49acb46ac0dca077e0>`__
+* Allow headers to be passed to the seeder application (sethg) : `947b531 <https://github.com/mapserver/mapcache/commit/947b5313819798d3178f7cbf4d5b832eec434a7f>`__
+* Set environment variables in config file and send to cURL (sethg) : `bc9d4a0 <https://github.com/mapserver/mapcache/commit/bc9d4a0cbf6e0864ce92a00645d77a41a8877086>`__
+* Update sample XML with new resolutions (sethg) : `912750e <https://github.com/mapserver/mapcache/commit/912750e21a919fc8efe4eceedfa753be8a1c6192>`__
+* Update test (sethg) : `04d91e5 <https://github.com/mapserver/mapcache/commit/04d91e5d10a4fd49324fbe28d30f8807bbccdb0c>`__
+* Update nlevels (sethg) : `54304f9 <https://github.com/mapserver/mapcache/commit/54304f957860f3bdd61eccd07525e7414c3c4dd4>`__
+* Add additional zoom levels (sethg) : `e23aaab <https://github.com/mapserver/mapcache/commit/e23aaabddac68e568a4599aadbf7af4e41d95a5d>`__
+* Fix memory issues (sethg) : `f2de657 <https://github.com/mapserver/mapcache/commit/f2de657fac1fccdb62c0994abac3bd1a397f60bd>`__
+* Revert replacement (sethg) : `6af496f <https://github.com/mapserver/mapcache/commit/6af496f8908301266a4867c3eb75734d3fa5adf1>`__
+* Use a string copy (sethg) : `66800cf <https://github.com/mapserver/mapcache/commit/66800cf12bb86d9a5facdb57311c906d2f05c048>`__
+* export mapcache_util_str_replace_all for Windows (sethg) : `6c0b4ea <https://github.com/mapserver/mapcache/commit/6c0b4ea996b7ddd72b3f883d82e5330c1b3e8670>`__
+* Use mapcache_util_str_replace_all (sethg) : `3a59bfd <https://github.com/mapserver/mapcache/commit/3a59bfde831cc56773751bf9091192deb3af73ba>`__
+* Fix lint issue (sethg) : `5cf2551 <https://github.com/mapserver/mapcache/commit/5cf2551aa073ba5ec6e999697e9dff4692440f2e>`__
+* Move to own function (sethg) : `42fa822 <https://github.com/mapserver/mapcache/commit/42fa8220a91463c42c57729c213fcded8af78bb0>`__
+* Add HTTP headers to ctx object (sethg) : `7ee7c4e <https://github.com/mapserver/mapcache/commit/7ee7c4e6bd700d45db7ebd43db7d06ef225635b8>`__
+* Update to latest SDK (sethg) : `94a5ed3 <https://github.com/mapserver/mapcache/commit/94a5ed3b4ee131bb04fd621113702535d711fa9f>`__
+* move include from mapcache.h to cache_redis.c and comment cleanup (Boris Manojlovic) : `08192ce <https://github.com/mapserver/mapcache/commit/08192ce4426eab3c76b89123bdaf5549eb66ac15>`__
+* cleanup (Boris Manojlovic) : `7195135 <https://github.com/mapserver/mapcache/commit/7195135fe49eeb77984d1f7a256a99c508b4e902>`__
+* replace with newer logic get_tile (Boris Manojlovic) : `fcf65cb <https://github.com/mapserver/mapcache/commit/fcf65cb7e5c7262fa7f83f33d7ace9db543bf97c>`__
+* porting code to newer logic (Boris Manojlovic) : `503f166 <https://github.com/mapserver/mapcache/commit/503f166851cfab39822cf45a196c9e7fa895f4cc>`__
+* Use `cached_value` when available but fallback to `requested_value` (Fabian Schindler) : `d0300b4 <https://github.com/mapserver/mapcache/commit/d0300b4f56dd3e2bdc7b4c8a91d86c163bf6a843>`__
+* Fixing wrong used dimension lookup Fixes  `#246 <https://github.com/mapserver/mapcache/issues/246>`__  (Fabian Schindler) : `8298647 <https://github.com/mapserver/mapcache/commit/8298647ab2f88fc68f3b7e8c24de7ed11972be32>`__
+* add Github sponsor button (Jeff McKenna) : `4740184 <https://github.com/mapserver/mapcache/commit/47401841633f935972926985e92d557e36ec0af0>`__
+* bugfix (jbo-ads) : `328ddc4 <https://github.com/mapserver/mapcache/commit/328ddc46220bf33a42dc087dfa103af8660f9af9>`__
+* bugfix (jbo-ads) : `b57a012 <https://github.com/mapserver/mapcache/commit/b57a012eedd70fb6f60a97103883cfd8ed372864>`__
+* Allow paths in dimension values for second level dimensions (jbo-ads) : `3bca2c6 <https://github.com/mapserver/mapcache/commit/3bca2c6ed2808b331960b4d0445fc825635abee2>`__
+* Show progress when skipping a tile, add non-interactive mode to get a newline all the time (Ruben Nijveld) : `fffd9d5 <https://github.com/mapserver/mapcache/commit/fffd9d5b8b68d3a3a7695debd696ecd2cf05735e>`__
+* Appropriately Allocate Storage (Eric Scrivner) : `1fffe1b <https://github.com/mapserver/mapcache/commit/1fffe1b18f5d103bb4b211a26fbf7403d7e2f8b0>`__
+* [Redis] Improve Error Handling On Port Parsing (Eric Scrivner) : `93cf334 <https://github.com/mapserver/mapcache/commit/93cf33454250984f4829574d044fdea51964cd4a>`__
+* Move mapcache_cache Member To Top Of Struct (Eric Scrivner) : `e2e5b9f <https://github.com/mapserver/mapcache/commit/e2e5b9fd96c064815a09b570706c89c7e685fbb7>`__
+* Correct Argument Ordering (Eric Scrivner) : `cea86d5 <https://github.com/mapserver/mapcache/commit/cea86d59794a1f279ef986868402785854acac92>`__
+* [Redis] Use SETEX Operation Rather Than SET/EXPIRE (Eric Scrivner) : `7c6a171 <https://github.com/mapserver/mapcache/commit/7c6a171e80d6cf95e73601f3efab4cad3c78ea78>`__
+* [Redis] Update XML Sample With Redis Config (Eric Scrivner) : `ca6fa7c <https://github.com/mapserver/mapcache/commit/ca6fa7c06e380ad4caa756333d4ac5d1d2481705>`__
+* [Redis] Remove Duplicate Lines (Eric Scrivner) : `21048fc <https://github.com/mapserver/mapcache/commit/21048fce1595badfef64d4c933ab0d02d5fbbda6>`__
+* [Redis] Add Modified Files From Patch (Eric Scrivner) : `54b6860 <https://github.com/mapserver/mapcache/commit/54b6860696e14414ce3a9853c2bf6033a13083be>`__
+* [Redis] Apply Patch To Add Redis Support (Eric Scrivner) : `3d61a91 <https://github.com/mapserver/mapcache/commit/3d61a913aa908fc32270850e002b7fdf5f7db703>`__

--- a/en/development/changelog/mapcache/index.txt
+++ b/en/development/changelog/mapcache/index.txt
@@ -8,6 +8,7 @@
 .. toctree::
    :maxdepth: 2
 
+   changelog-1-12
    changelog-1-10
    changelog-1-8
    changelog-1-6

--- a/en/download_archives.txt
+++ b/en/download_archives.txt
@@ -120,6 +120,8 @@ Past Releases
 Development Releases
 ..............................................................................
 
+* **2022-01-27** `mapcache-1.12.0-rc1.tar.gz <https://download.osgeo.org/mapserver/mapcache-1.12.0-rc1.tar.gz>`__ :ref:`Changelog <changelog-mapcache-1-12-0-rc1>`
+
 * **2020-05-04** `mapserver-7.6.0-rc4.tar.gz`_ :ref:`Changelog <changelog-7-6>`
 
 * **2020-04-24** `mapserver-7.6.0-rc3.tar.gz`_ :ref:`Changelog <changelog-7-6>`

--- a/en/include/announcements.inc
+++ b/en/include/announcements.inc
@@ -1,3 +1,11 @@
+**2022-01-27 - MapCache 1.12.0-rc1 is released**
+
+The first release candidate of MapCache 1.12.0 is now available.
+See the :ref:`1.12.0-rc1 changelog <changelog-mapcache-1-12-0-rc1>`
+for the full list of changes.  
+
+Head to :ref:`download <dev-release>` to obtain a copy.
+
 **2021-07-12 - MapServer 7.6.4 is released**
 
 The maintenance release of MapServer 7.6.4 is now available.


### PR DESCRIPTION
- related to https://github.com/MapServer/mapcache/pull/279