### PR TITLE
Document MapCache seeder switch

### DIFF
--- a/en/mapcache/seed.txt
+++ b/en/mapcache/seed.txt
@@ -45,6 +45,10 @@ tileset must reference the given grid).
 
 **-h | --help**: show help.
 
+**-H | --header "HEADER=VALUE"**: used to specify a key-value pair to set an
+HTTP header in a forwarding rule or HTTP request. Can be used multiple times to set multiple
+headers, e.g. -H "CUSTOM-HEADER1=VAL1" -H "CUSTOM-HEADER2=VAL2".
+
 **-i | --iteration-mode**: either "*drill-down*" or "*scanline*".
 Default is to use drill-down for g, WGS84 and GoogleMapsCompatible grids, and
 scanline for others. Use this flag to override. (scanline was formerly 


### PR DESCRIPTION
Document the new `-H` switch added in https://github.com/MapServer/mapcache/pull/262 and released in MapCache 1.12