### PR TITLE
Added COMPFILTER to documentation

### DIFF
--- a/en/mapfile/composite.txt
+++ b/en/mapfile/composite.txt
@@ -10,8 +10,8 @@
 Background
 ==========
 
-The `COMPOSITE` block is used to achieve blending effects with
-MapServer.
+Available since MapServer 7.0, the `COMPOSITE` block is used to achieve 
+blending effects with MapServer.
 
 Some cartographic renderings benefit from the addition of advanced
 blending modes, as explained in detail in `Blend Modes`_.  This
@@ -30,34 +30,25 @@ Parameters
 ==========
 
 .. index::
-   pair: COMPOSITE; OPACITY
-   :name: mapfile-composite-opacity
-    
-.. _opacity:
-
-OPACITY [integer]
-    Sets the opacity level (or the inability to see through the layer) of all
-    classed pixels for a given layer. Must be between 0 to 100. A value of 100 is opaque and
-    0 is fully transparent.
-
-.. index::
     pair: COMPOSITE; COMPFILTER
  :name: mapfile-composite-compfilter
   
 COMPFILTER [string]
+    .. versionadded:: 7.2
+    
     Name of the compositing filter. The primary purpose is to enable soft shadow 
     and blurring effects, although other usages can exist or could be added in 
     the future. Several compfilters can be placed after another to create a combined
     effect. For example a blur and translate effect can be combined to make a 
     soft shadow effect behind a feature.
     
-The currently available filters are:
+    The currently available filters are:
 
-   - blur(integer)
-   - translate(integer,integer)
-   - grayscale()
-   - blacken()
-   - whiten()
+    - blur(integer)
+    - translate(integer,integer)
+    - grayscale()
+    - blacken()
+    - whiten()
    
 .. index::
     pair: COMPOSITE; COMPOP
@@ -218,6 +209,17 @@ COMPOP [string]
     Operators marked with a star (*) will only be supported when using an AGG
     backends *and* when pixman support is not enabled, and will fall back to
     "src-over" when this is not the case.
+
+.. index::
+   pair: COMPOSITE; OPACITY
+   :name: mapfile-composite-opacity
+    
+.. _opacity:
+
+OPACITY [integer]
+    Sets the opacity level (or the inability to see through the layer) of all
+    classed pixels for a given layer. Must be between 0 to 100. A value of 100 is opaque and
+    0 is fully transparent.
 
 Usage
 =====

--- a/en/mapfile/composite.txt
+++ b/en/mapfile/composite.txt
@@ -41,9 +41,28 @@ OPACITY [integer]
     0 is fully transparent.
 
 .. index::
+    pair: COMPOSITE; COMPFILTER
+ :name: mapfile-composite-compfilter
+  
+COMPFILTER [string]
+    Name of the compositing filter. The primary purpose is to enable soft shadow 
+    and blurring effects, although other usages can exist or could be added in 
+    the future. Several compfilters can be placed after another to create a combined
+    effect. For example a blur and translate effect can be combined to make a 
+    soft shadow effect behind a feature.
+    
+The currently available filters are:
+
+   - blur(integer)
+   - translate(integer,integer)
+   - grayscale()
+   - blacken()
+   - whiten()
+   
+.. index::
     pair: COMPOSITE; COMPOP
  :name: mapfile-composite-compop
-   
+
 COMPOP [string]
     Name of the compositing operator to use when blending the temporary image
     onto the main map image. See `http://en.wikipedia.org/wiki/Blend_modes`.


### PR DESCRIPTION
Description of the compfilter based on original info I read, is in this users-list entry by Thomas B.

https://lists.osgeo.org/pipermail/mapserver-users/2015-October/078298.html

Fixes:  Compfilter description is missing in the COMPISTE page #677 