### PR TITLE
minor TinyOWS GitHub url change

### DIFF
--- a/en/mapcache/install.txt
+++ b/en/mapcache/install.txt
@@ -14,7 +14,7 @@ Compilation & Installation
 :Contact: mathieu.coudert at gmail.com
 :Author: Seth Girvin
 :Contact: sgirvin at compass.ie
-:Last Updated: 2021-08-31
+:Last Updated: 2022-06-04
 
 .. contents:: Table of Contents
     :depth: 3
@@ -29,7 +29,7 @@ with either:
 .. code-block:: bash
 
    # readonly
-   git clone git://github.com/MapServer/mapcache.git
+   git clone https://github.com/MapServer/mapcache.git
    # ssh authenticated
    git clone git@github.com:MapServer/mapcache.git
    # tarball

--- a/en/tinyows/serverinstallation.txt
+++ b/en/tinyows/serverinstallation.txt
@@ -38,7 +38,7 @@ and git application .
 
   ::
 
-    $ git clone git://github.com/mapserver/tinyows.git
+    $ git clone https://github.com/MapServer/tinyows.git
     $ cd tinyows
     $ autoconf
     $ ./configure


### PR DESCRIPTION
- same fix applied for MapCache url also