### PR TITLE
Fix to plugin documentation

### DIFF
--- a/en/mapfile/layer.txt
+++ b/en/mapfile/layer.txt
@@ -963,17 +963,17 @@ OPACITY [integer|alpha]
 
 PLUGIN [filename]
     Additional library to load by MapServer, for this layer.  This is commonly
-    used to load specific support for SDE and Microsoft SQL Server layers,
+    used to load specific support for Oracle and Microsoft SQL Server layers,
     such as:
 
       .. code-block:: mapfile
 
         CONNECTIONTYPE PLUGIN
-        CONNECTION "hostname,port:xxx,database,username,password"
-        PLUGIN "sde"
-        DATA "layername,geometrycolumn,SDE.DEFAULT"
+        CONNECTION "username/password@hostname:port/database"
+        PLUGIN "oci"
+        DATA "geometrycolumn FROM schema.table USING UNIQUE column SRID 4326"
 	
-    Where "sde" is an alias mapped in the global configuration file
+    Where "oci" is an alias mapped in the global configuration file
     
       .. code-block:: mapfile
       
@@ -981,7 +981,6 @@ PLUGIN [filename]
           # new keyed approach to plugins
           "mssql" "C:/apps/gisinternals/bin/ms/plugins/mssql2008/msplugin_mssql2008.dll"
           "oci" "C:/apps/gisinternals/bin/ms/plugins/oci/msplugin_oracle.dll"
-          "sde" "C:/ms4w/Apache/specialplugins/msplugin_sde_92.dll"
         END
 
 .. index::

--- a/en/mapfile/layer.txt
+++ b/en/mapfile/layer.txt
@@ -970,8 +970,19 @@ PLUGIN [filename]
 
         CONNECTIONTYPE PLUGIN
         CONNECTION "hostname,port:xxx,database,username,password"
-        PLUGIN "C:/ms4w/Apache/specialplugins/msplugin_sde_92.dll"
+        PLUGIN "sde"
         DATA "layername,geometrycolumn,SDE.DEFAULT"
+	
+    Where "sde" is an alias mapped in the global configuration file
+    
+      .. code-block:: mapfile
+      
+        PLUGINS
+          # new keyed approach to plugins
+          "mssql" "C:/apps/gisinternals/bin/ms/plugins/mssql2008/msplugin_mssql2008.dll"
+          "oci" "C:/apps/gisinternals/bin/ms/plugins/oci/msplugin_oracle.dll"
+          "sde" "C:/ms4w/Apache/specialplugins/msplugin_sde_92.dll"
+        END
 
 .. index::
    pair: LAYER; POSTLABELCACHE


### PR DESCRIPTION
Changed LAYER plugin documentation to reflect use of plugin alias over direct reference in mapfile following changes introduced in version 8.  Changed plugin example to Oracle over SDE, as SDE is no longer supported.