### PR TITLE
Fix typo in mapscript/python

### DIFF
--- a/en/mapscript/python.txt
+++ b/en/mapscript/python.txt
@@ -48,7 +48,7 @@ imageObj Extended Methods
 
 
 
-+ :func:`imageObj.write` - 1rite image data to a Python file-like object.  Default is stdout.
++ :func:`imageObj.write` - write image data to a Python file-like object.  Default is stdout.
 
 .. code-block:: python
 


### PR DESCRIPTION
Changed `1rite` to `write` in function description.