### PR TITLE
Update MapScript version to generate latest docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
   - secure: T5msa8CU0jcIs2m6sgZk48dppJcljWX9LFQlREqxMdW/cpUIpoi1/2Gkg2AE5GqLqiNhz7T/IKzzwnhB61uuIsoYDbT31S6wkUBEtZIUjhfvuqE007sr9r5rSAQsoz8geonmXejVj5c6Q7rjePLONRqZcUsXe7biL27hWP90s1s=
   
 script:
-- pip install --index-url https://test.pypi.org/simple/ mapscript==7.7.4
+- pip install --index-url https://test.pypi.org/simple/ mapscript==8.0.1
 - "./scripts/travis_build_docs.sh"
 after_success:
 - echo "$TRAVIS_SECURE_ENV_VARS"

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
   - secure: T5msa8CU0jcIs2m6sgZk48dppJcljWX9LFQlREqxMdW/cpUIpoi1/2Gkg2AE5GqLqiNhz7T/IKzzwnhB61uuIsoYDbT31S6wkUBEtZIUjhfvuqE007sr9r5rSAQsoz8geonmXejVj5c6Q7rjePLONRqZcUsXe7biL27hWP90s1s=
   
 script:
-- pip install --index-url https://test.pypi.org/simple/ mapscript==8.0.1
+- pip install --index-url https://pypi.org/simple/ mapscript==8.0.1
 - "./scripts/travis_build_docs.sh"
 after_success:
 - echo "$TRAVIS_SECURE_ENV_VARS"


### PR DESCRIPTION
This will download the new 8.0.1 MapScript Python wheel  from https://pypi.org/project/mapscript/8.0.1/ to automatically create the MapScript API documentation e.g. https://mapserver.org/mapscript/mapscript-api/stub/mapscript.mapObj.html#mapscript.mapObj

