### PR TITLE
Switch to Python MapScript with comments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,12 +28,12 @@ env:
   - secure: T5msa8CU0jcIs2m6sgZk48dppJcljWX9LFQlREqxMdW/cpUIpoi1/2Gkg2AE5GqLqiNhz7T/IKzzwnhB61uuIsoYDbT31S6wkUBEtZIUjhfvuqE007sr9r5rSAQsoz8geonmXejVj5c6Q7rjePLONRqZcUsXe7biL27hWP90s1s=
   
 script:
-- pip install --index-url https://pypi.org/simple/ mapscript==8.0.1
+- pip install --index-url https://test.pypi.org/simple/ mapscript==8.1.0
 - "./scripts/travis_build_docs.sh"
 after_success:
 - echo "$TRAVIS_SECURE_ENV_VARS"
 - touch ./build/html/.nojekyll
-#- sh -c 'if test "$TRAVIS_SECURE_ENV_VARS" = "true" -a "$TRAVIS_BRANCH" = "main"; then echo "publish website"; ./scripts/travis_add_deploy_key.sh; ./scripts/travis_deploy_website.sh build /tmp; fi'
+- sh -c 'if test "$TRAVIS_SECURE_ENV_VARS" = "true" -a "$TRAVIS_BRANCH" = "main"; then echo "publish website"; ./scripts/travis_add_deploy_key.sh; ./scripts/travis_deploy_website.sh build /tmp; fi'
 notifications:
   irc:
     channels:


### PR DESCRIPTION
As noted in https://github.com/MapServer/MapServer/pull/6892 the Python MapScript uploaded to PyPI didn't contain the doxygen comments used to create the MapScript API docs. 
I've uploaded a new version to test.pypi.org with comments so switching to this should resolve the missing MapScript docs (see current live docs with empty comments: https://mapserver.org/mapscript/mapscript-api/stub/mapscript.mapObj.html#mapscript.mapObj

The Travis script to generate docs (added in #610) from the main branch was commented out in https://github.com/MapServer/MapServer-documentation/commit/85716ce75db8c9e0828cabfb9e4baf5dfee6334e. This means it is currently not possible to review changes added to main at https://mapserver.github.io/MapServer-documentation/ before backporting to the live docs (or to review docs for an upcoming release). 

I've readded the call to the script - I can debug and fix if there are issues with Travis and this script. 