### PR TITLE
Add note about CONFIG MAPS keys in URLs

### DIFF
--- a/en/mapfile/config.txt
+++ b/en/mapfile/config.txt
@@ -69,10 +69,15 @@ ENV
 MAPS
     This block allows for aliases to be mapped to mapfile paths. If the ``MS_MAP_NO_PATH`` environment
     variable is set then **only** these aliases can be used in the ``map=`` CGI parameter.
+
+    Aliases are case-insensitive - "ITASCA" and "Itasca" are handled identically.
+
     The use of aliases also helps to simplify :ref:`ogcapi` URLs, for example the alias 
     ``itasca`` can be used in the place of a mapfile path in a URL for example: 
-    http://localhost/mapserver/itasca/ogcapi/collections
-    Aliases are case-insensitive - "ITASCA" and "Itasca" are handled identically.
+    http://localhost/mapserver/itasca/ogcapi/collections. 
+
+    As of MapServer 8.2 *all* types of MapServer requests can use keys from the ``MAPS`` block in the config file
+    as part of a URL for example http://localhost/itasca/?request=WMS&...
     
     .. code-block:: mapfile
 


### PR DESCRIPTION
Add note for the update in https://github.com/MapServer/MapServer/pull/6862 that allows keys in the ``CONFIG`` file to be used by all types of requests. 