### PR TITLE
Add horizontal scrollbar to TOC when required

### DIFF
--- a/_static/custom.css
+++ b/_static/custom.css
@@ -1,0 +1,11 @@
+/*
+    Added for MapScript API docs
+*/
+
+table.align-default {
+    margin-left: 0px;
+}
+
+div.sphinxsidebarwrapper {
+    overflow-y: scroll;
+}

--- a/_static/sphinx.css
+++ b/_static/sphinx.css
@@ -284,10 +284,3 @@ div.service-provider {
 span.pre {
     font-family: 'Consolas', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono';
 }
-
-/*
-    Added for MapScript API docs
-*/
-table.align-default {
-    margin-left: 0px;
-}

--- a/conf.py
+++ b/conf.py
@@ -162,6 +162,7 @@ html_static_path = ['_static']
 html_last_updated_fmt = '%Y-%m-%d'
 
 html_css_files = [
+    'custom.css',
     'ribbon.css'
 ]
 


### PR DESCRIPTION
Currently due to long constant names there are overlaps between the TOC and the content at https://mapserver.org/mapscript/mapscript-api/index.html

![image](https://github.com/MapServer/MapServer-documentation/assets/490840/50df60dd-1c93-4b45-b14b-5904fb51832f)

This pull request ensures a horizontal scrollbar is used (when required) to avoid this overlap.

![image](https://github.com/MapServer/MapServer-documentation/assets/490840/ce27d59b-5494-4c11-9d4e-2a24e8bf6ae4)

I was hoping the local TOC could be modified on that page, but it does not appeat to be possible. Failed attempts included adding:

```
.. toctree::
   :hidden:
   :maxdepth: 2

.. contents:: Table of Contents
   :local:
   :depth: 2
```

And also trying to modify localtoc2.html similar to how the Read the Docs theme works with the [global TOC](https://sphinx-rtd-theme.readthedocs.io/en/stable/configuring.html#confval-navigation_depth), but this does not work with `toc`:

```
{%- if display_toc %}
  <h3>{{ _('Current Table Of Contents') }}</h3>
  {{ toc(maxdepth=2) }}
{%- endif %}
```
