### PR TITLE
upgrade to Sphinx 7.2.2

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -353,6 +353,12 @@ locale_dirs = ['../translated']
 
 rst_epilog = """
 .. |RUNSUB| replace:: This attribute can be replaced using runtime substitution. See :ref:`RUNSUB`.
+.. role:: raw-html(raw)
+   :format: html
+.. |construction| replace:: :raw-html:`&#128679;`
+.. |green-check-mark| replace:: :raw-html:`&#x2705;`
+.. |red-cross-mark| replace:: :raw-html:`&#10060;`
+.. |red-question-mark| replace:: :raw-html:`&#10067;`
 """
 
 from pygments.lexer import RegexLexer, bygroups,combined, include

--- a/conf.py
+++ b/conf.py
@@ -49,8 +49,7 @@ sys.path.append(os.path.abspath('.'))
 #extensions = ['labels' ,'rst2pdf.pdfbuilder']
 #extensions = ['labels', 'sphinxcontrib.spelling']
 
-extensions = ['labels', 'sphinx_removed_in', 'sphinx.ext.autodoc', 'sphinx.ext.autosummary', 'sphinx.ext.viewcode',
-             'sphinxemoji.sphinxemoji']
+extensions = ['labels', 'sphinx_removed_in', 'sphinx.ext.autodoc', 'sphinx.ext.autosummary', 'sphinx.ext.viewcode']
 
 autosummary_generate = True # when True create a page for each mapscript class
 

--- a/en/development/rfc/ms-rfc-134.txt
+++ b/en/development/rfc/ms-rfc-134.txt
@@ -373,13 +373,13 @@ Current Status
    +-------------------------------------------------------------+----------------------+   
    | Features: Collections (single layer: list queryable fields) | |red-cross-mark|     |
    +-------------------------------------------------------------+----------------------+   
-   | Features: Collections (single layer: map)                   | |construction|       |
+   | Features: Collections (single layer: map)                   | |red-cross-mark|     |
    +-------------------------------------------------------------+----------------------+      
-   | Features: API docs                                          | |construction|       |
+   | Features: API docs                                          | |red-cross-mark|     |
    +-------------------------------------------------------------+----------------------+   
    | Features: msautotests                                       | |construction|       |
    +-------------------------------------------------------------+----------------------+   
-   | Features: user docs on mapserver.org                        | |construction|       |
+   | Features: user docs on mapserver.org                        | |red-cross-mark|     |
    +-------------------------------------------------------------+----------------------+   
 
 Issues / Tasks / Wishlist

--- a/en/development/rfc/ms-rfc-134.txt
+++ b/en/development/rfc/ms-rfc-134.txt
@@ -361,25 +361,25 @@ Current Status
    +-------------------------------------------------------------+----------------------+
    | Support                                                     | Status               |
    +=============================================================+======================+
-   | Features: Landing page                                      | |:construction:|     |
+   | Features: Landing page                                      | |construction|       |
    +-------------------------------------------------------------+----------------------+
-   | Features: JSON & HTML output                                | |:heavy_check_mark:| |
+   | Features: JSON & HTML output                                | |green-check-mark|   |
    +-------------------------------------------------------------+----------------------+
-   | Features: Collections (layer listing)                       | |:construction:|     |
+   | Features: Collections (layer listing)                       | |construction|       |
    +-------------------------------------------------------------+----------------------+
-   | Features: Collections (single layer: links (summary)        | |:construction:|     |
+   | Features: Collections (single layer: links (summary)        | |construction|       |
    +-------------------------------------------------------------+----------------------+   
-   | Features: Collections (single layer: query)                 | |:construction:|     |
+   | Features: Collections (single layer: query)                 | |construction|       |
    +-------------------------------------------------------------+----------------------+   
-   | Features: Collections (single layer: list queryable fields) | |:stop_sign:|        |
+   | Features: Collections (single layer: list queryable fields) | |red-cross-mark|     |
    +-------------------------------------------------------------+----------------------+   
-   | Features: Collections (single layer: map)                   | |:stop_sign:|        |
+   | Features: Collections (single layer: map)                   | |construction|       |
    +-------------------------------------------------------------+----------------------+      
-   | Features: API docs                                          | |:stop_sign:|        |
+   | Features: API docs                                          | |construction|       |
    +-------------------------------------------------------------+----------------------+   
-   | Features: msautotests                                       | |:construction:|     |
+   | Features: msautotests                                       | |construction|       |
    +-------------------------------------------------------------+----------------------+   
-   | Features: user docs on mapserver.org                        | |:stop_sign:|        |
+   | Features: user docs on mapserver.org                        | |construction|       |
    +-------------------------------------------------------------+----------------------+   
 
 Issues / Tasks / Wishlist

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 alabaster==0.7.13
-sphinx==7.1.0
+sphinx==7.2.2
 sphinx-removed-in==0.2.1
-sphinxemoji==0.2.0


### PR DESCRIPTION
- also removes the `sphinxemoji` extension, to use raw hex codes instead (one less extension to support each upgrade)