### PR TITLE
introcuce use of alias on wms_server

### DIFF
--- a/en/ogc/wms_server.txt
+++ b/en/ogc/wms_server.txt
@@ -318,13 +318,13 @@ Let's go through each of these parameters in more detail:
     http://my.host.com/cgi-bin/mapserv?map=/path/to/your-mapfile.map" #must change mapfile path
           
 
-  By creating a wrapper script on the server it is possible to hide
-  the "map=" parameter from the URL and then your server's online
-  resource URL could be something like:
+  By setting an :ref:`alias in map config <mapfile-config-maps>` (or creating a wrapper script 
+  on the server) it is possible to hide the "map=" parameter from 
+  the URL and then your server's online resource URL could be something like:
 
   ::
   
-    http://my.host.com/cgi-bin/mywms?
+    http://my.host.com/mywms?
           
 
   This is covered in more detail in the section "More About the Online
@@ -628,6 +628,20 @@ which is defined as an opaque string terminated by "?" or "&" (See
 But anyway, even if it's valid, the above URL is still ugly. And you
 might want to use a nicer URL for your WMS Online Resource URL. Here
 are some suggestions:
+
+.. index::
+   pair: Mapserver; Alias
+
+Mapserver Alias in config
+-----------------------------------------
+
+Since Mapserver 8.2 it is possible to configure a set of :ref:`map aliases
+in config <mapfile-config-maps>`. An alias can be used as a parameter in 
+path, to reference the configured mapfile for that alias.
+
+::
+
+  https://example.com/myalias?service=wms&request=GetCapabilities
 
 .. index::
    pair: Apache; ReWriteRule


### PR DESCRIPTION
this adds the use of aliases to the options to hide the &map=xxx parameter from querystring

I wonder if it makes sense to deprecate other suggested methods 