### PR TITLE
MapScript Documentation Updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ env:
   - secure: T5msa8CU0jcIs2m6sgZk48dppJcljWX9LFQlREqxMdW/cpUIpoi1/2Gkg2AE5GqLqiNhz7T/IKzzwnhB61uuIsoYDbT31S6wkUBEtZIUjhfvuqE007sr9r5rSAQsoz8geonmXejVj5c6Q7rjePLONRqZcUsXe7biL27hWP90s1s=
   
 script:
-- pip install --index-url https://test.pypi.org/simple/ mapscript==8.1.0
 - "./scripts/travis_build_docs.sh"
 after_success:
 - echo "$TRAVIS_SECURE_ENV_VARS"

--- a/en/mapscript/mapscript-api/constants/config.rst
+++ b/en/mapscript/mapscript-api/constants/config.rst
@@ -1,0 +1,19 @@
+.. _mapfile-constants-config:
+
+Config
+++++++
+
+.. hlist::
+   :columns: 3
+    
+   * .. autodata:: mapscript.MS_CONFIG_SECTION
+        :annotation: 3000
+
+   * .. autodata:: mapscript.MS_CONFIG_SECTION_ENV
+        :annotation: 3001
+
+   * .. autodata:: mapscript.MS_CONFIG_SECTION_MAPS
+        :annotation: 3002
+
+   * .. autodata:: mapscript.MS_CONFIG_SECTION_PLUGINS
+        :annotation: 3003

--- a/en/mapscript/mapscript-api/constants/connection.rst
+++ b/en/mapscript/mapscript-api/constants/connection.rst
@@ -59,3 +59,6 @@ Connection
 
    * .. autodata:: mapscript.MS_IDW
         :annotation: 18
+
+   * .. autodata:: mapscript.MS_FLATGEOBUF
+        :annotation: 19

--- a/en/mapscript/mapscript-api/constants/error.rst
+++ b/en/mapscript/mapscript-api/constants/error.rst
@@ -132,5 +132,11 @@ Error
    * .. autodata:: mapscript.MS_V8ERR
         :annotation: 43
 
-   * .. autodata:: mapscript.MS_NUMERRORCODES
+   * .. autodata:: mapscript.MS_OGCAPIERR
         :annotation: 44
+
+   * .. autodata:: mapscript.MS_FGBERR
+        :annotation: 45
+
+   * .. autodata:: mapscript.MS_NUMERRORCODES
+        :annotation: 46

--- a/en/mapscript/mapscript-api/constants/function.rst
+++ b/en/mapscript/mapscript-api/constants/function.rst
@@ -42,17 +42,29 @@ Function
    * .. autodata:: mapscript.MS_TOKEN_FUNCTION_SMOOTHSIA
         :annotation: 361
 
-   * .. autodata:: mapscript.MS_TOKEN_FUNCTION_JAVASCRIPT
+   * .. autodata:: mapscript.MS_TOKEN_FUNCTION_CENTERLINE
         :annotation: 362
 
-   * .. autodata:: mapscript.MS_TOKEN_FUNCTION_UPPER
+   * .. autodata:: mapscript.MS_TOKEN_FUNCTION_DENSIFY
         :annotation: 363
 
-   * .. autodata:: mapscript.MS_TOKEN_FUNCTION_LOWER
+   * .. autodata:: mapscript.MS_TOKEN_FUNCTION_OUTER
         :annotation: 364
 
-   * .. autodata:: mapscript.MS_TOKEN_FUNCTION_INITCAP
+   * .. autodata:: mapscript.MS_TOKEN_FUNCTION_INNER
         :annotation: 365
 
-   * .. autodata:: mapscript.MS_TOKEN_FUNCTION_FIRSTCAP
+   * .. autodata:: mapscript.MS_TOKEN_FUNCTION_JAVASCRIPT
         :annotation: 366
+
+   * .. autodata:: mapscript.MS_TOKEN_FUNCTION_UPPER
+        :annotation: 367
+
+   * .. autodata:: mapscript.MS_TOKEN_FUNCTION_LOWER
+        :annotation: 368
+
+   * .. autodata:: mapscript.MS_TOKEN_FUNCTION_INITCAP
+        :annotation: 369
+
+   * .. autodata:: mapscript.MS_TOKEN_FUNCTION_FIRSTCAP
+        :annotation: 370

--- a/en/mapscript/mapscript-api/constants/index.rst
+++ b/en/mapscript/mapscript-api/constants/index.rst
@@ -2,6 +2,7 @@
 .. include:: constants/allocations.rst
 .. include:: constants/comparison.rst
 .. include:: constants/compop.rst
+.. include:: constants/config.rst
 .. include:: constants/connection.rst
 .. include:: constants/dbconnection.rst
 .. include:: constants/dbffields.rst
@@ -17,10 +18,12 @@
 .. include:: constants/labeloffset.rst
 .. include:: constants/labelsize.rst
 .. include:: constants/layer.rst
+.. include:: constants/legend.rst
 .. include:: constants/limiters.rst
 .. include:: constants/linejoin.rst
 .. include:: constants/logicalcontrol.rst
 .. include:: constants/measureshape.rst
+.. include:: constants/missing.rst
 .. include:: constants/parse.rst
 .. include:: constants/position.rst
 .. include:: constants/projections.rst
@@ -30,6 +33,7 @@
 .. include:: constants/rendermode.rst
 .. include:: constants/requesttype.rst
 .. include:: constants/returncodes.rst
+.. include:: constants/scalebar.rst
 .. include:: constants/shapefile.rst
 .. include:: constants/shapetype.rst
 .. include:: constants/stylebinding.rst

--- a/en/mapscript/mapscript-api/constants/legend.rst
+++ b/en/mapscript/mapscript-api/constants/legend.rst
@@ -1,0 +1,19 @@
+.. _mapfile-constants-legend:
+
+Legend
+++++++
+
+.. hlist::
+   :columns: 3
+    
+   * .. autodata:: mapscript.MS_LEGEND_KEYSPACING_MIN
+        :annotation: 0
+
+   * .. autodata:: mapscript.MS_LEGEND_KEYSIZE_MIN
+        :annotation: 5
+
+   * .. autodata:: mapscript.MS_LEGEND_KEYSPACING_MAX
+        :annotation: 50
+
+   * .. autodata:: mapscript.MS_LEGEND_KEYSIZE_MAX
+        :annotation: 200

--- a/en/mapscript/mapscript-api/constants/missing.rst
+++ b/en/mapscript/mapscript-api/constants/missing.rst
@@ -6,11 +6,71 @@ Missing
 .. hlist::
    :columns: 3
     
-   * .. autodata:: mapscript.MS_INHERIT
-        :annotation: -1
+   * .. autodata:: mapscript.MS_SCALEBAR_OFFSET_MIN
+        :annotation: -50
 
-   * .. autodata:: mapscript.MS_FIRST_MATCHING_CLASS
+   * .. autodata:: mapscript.MS_LEGEND_KEYSPACING_MIN
         :annotation: 0
 
-   * .. autodata:: mapscript.MS_ALL_MATCHING_CLASSES
+   * .. autodata:: mapscript.MS_NUM_CHECK_NONE
+        :annotation: 0
+
+   * .. autodata:: mapscript.MS_NUM_CHECK_RANGE
         :annotation: 1
+
+   * .. autodata:: mapscript.MS_SCALEBAR_INTERVALS_MIN
+        :annotation: 1
+
+   * .. autodata:: mapscript.MS_NUM_CHECK_GT
+        :annotation: 2
+
+   * .. autodata:: mapscript.MS_SCALEBAR_HEIGHT_MIN
+        :annotation: 2
+
+   * .. autodata:: mapscript.MS_NUM_CHECK_GTE
+        :annotation: 3
+
+   * .. autodata:: mapscript.MS_LEGEND_KEYSIZE_MIN
+        :annotation: 5
+
+   * .. autodata:: mapscript.MS_SCALEBAR_WIDTH_MIN
+        :annotation: 5
+
+   * .. autodata:: mapscript.MS_RESOLUTION_MIN
+        :annotation: 10
+
+   * .. autodata:: mapscript.MS_FLATGEOBUF
+        :annotation: 19
+
+   * .. autodata:: mapscript.MS_LEGEND_KEYSPACING_MAX
+        :annotation: 50
+
+   * .. autodata:: mapscript.MS_SCALEBAR_OFFSET_MAX
+        :annotation: 50
+
+   * .. autodata:: mapscript.MS_SCALEBAR_HEIGHT_MAX
+        :annotation: 100
+
+   * .. autodata:: mapscript.MS_SCALEBAR_INTERVALS_MAX
+        :annotation: 100
+
+   * .. autodata:: mapscript.MS_LEGEND_KEYSIZE_MAX
+        :annotation: 200
+
+   * .. autodata:: mapscript.MS_RESOLUTION_MAX
+        :annotation: 1000
+
+   * .. autodata:: mapscript.MS_SCALEBAR_WIDTH_MAX
+        :annotation: 1000
+
+   * .. autodata:: mapscript.MS_CONFIG_SECTION
+        :annotation: 3000
+
+   * .. autodata:: mapscript.MS_CONFIG_SECTION_ENV
+        :annotation: 3001
+
+   * .. autodata:: mapscript.MS_CONFIG_SECTION_MAPS
+        :annotation: 3002
+
+   * .. autodata:: mapscript.MS_CONFIG_SECTION_PLUGINS
+        :annotation: 3003

--- a/en/mapscript/mapscript-api/constants/missing.rst
+++ b/en/mapscript/mapscript-api/constants/missing.rst
@@ -6,71 +6,20 @@ Missing
 .. hlist::
    :columns: 3
     
-   * .. autodata:: mapscript.MS_SCALEBAR_OFFSET_MIN
-        :annotation: -50
-
-   * .. autodata:: mapscript.MS_LEGEND_KEYSPACING_MIN
-        :annotation: 0
-
    * .. autodata:: mapscript.MS_NUM_CHECK_NONE
         :annotation: 0
 
    * .. autodata:: mapscript.MS_NUM_CHECK_RANGE
         :annotation: 1
 
-   * .. autodata:: mapscript.MS_SCALEBAR_INTERVALS_MIN
-        :annotation: 1
-
    * .. autodata:: mapscript.MS_NUM_CHECK_GT
-        :annotation: 2
-
-   * .. autodata:: mapscript.MS_SCALEBAR_HEIGHT_MIN
         :annotation: 2
 
    * .. autodata:: mapscript.MS_NUM_CHECK_GTE
         :annotation: 3
 
-   * .. autodata:: mapscript.MS_LEGEND_KEYSIZE_MIN
-        :annotation: 5
-
-   * .. autodata:: mapscript.MS_SCALEBAR_WIDTH_MIN
-        :annotation: 5
-
    * .. autodata:: mapscript.MS_RESOLUTION_MIN
         :annotation: 10
 
-   * .. autodata:: mapscript.MS_FLATGEOBUF
-        :annotation: 19
-
-   * .. autodata:: mapscript.MS_LEGEND_KEYSPACING_MAX
-        :annotation: 50
-
-   * .. autodata:: mapscript.MS_SCALEBAR_OFFSET_MAX
-        :annotation: 50
-
-   * .. autodata:: mapscript.MS_SCALEBAR_HEIGHT_MAX
-        :annotation: 100
-
-   * .. autodata:: mapscript.MS_SCALEBAR_INTERVALS_MAX
-        :annotation: 100
-
-   * .. autodata:: mapscript.MS_LEGEND_KEYSIZE_MAX
-        :annotation: 200
-
    * .. autodata:: mapscript.MS_RESOLUTION_MAX
         :annotation: 1000
-
-   * .. autodata:: mapscript.MS_SCALEBAR_WIDTH_MAX
-        :annotation: 1000
-
-   * .. autodata:: mapscript.MS_CONFIG_SECTION
-        :annotation: 3000
-
-   * .. autodata:: mapscript.MS_CONFIG_SECTION_ENV
-        :annotation: 3001
-
-   * .. autodata:: mapscript.MS_CONFIG_SECTION_MAPS
-        :annotation: 3002
-
-   * .. autodata:: mapscript.MS_CONFIG_SECTION_PLUGINS
-        :annotation: 3003

--- a/en/mapscript/mapscript-api/constants/scalebar.rst
+++ b/en/mapscript/mapscript-api/constants/scalebar.rst
@@ -1,0 +1,31 @@
+.. _mapfile-constants-scalebar:
+
+Scalebar
+++++++++
+
+.. hlist::
+   :columns: 3
+    
+   * .. autodata:: mapscript.MS_SCALEBAR_OFFSET_MIN
+        :annotation: -50
+
+   * .. autodata:: mapscript.MS_SCALEBAR_INTERVALS_MIN
+        :annotation: 1
+
+   * .. autodata:: mapscript.MS_SCALEBAR_HEIGHT_MIN
+        :annotation: 2
+
+   * .. autodata:: mapscript.MS_SCALEBAR_WIDTH_MIN
+        :annotation: 5
+
+   * .. autodata:: mapscript.MS_SCALEBAR_OFFSET_MAX
+        :annotation: 50
+
+   * .. autodata:: mapscript.MS_SCALEBAR_HEIGHT_MAX
+        :annotation: 100
+
+   * .. autodata:: mapscript.MS_SCALEBAR_INTERVALS_MAX
+        :annotation: 100
+
+   * .. autodata:: mapscript.MS_SCALEBAR_WIDTH_MAX
+        :annotation: 1000

--- a/en/mapscript/mapscript-api/constants/tokenbinding.rst
+++ b/en/mapscript/mapscript-api/constants/tokenbinding.rst
@@ -7,22 +7,22 @@ Token Binding
    :columns: 3
     
    * .. autodata:: mapscript.MS_TOKEN_BINDING_DOUBLE
-        :annotation: 370
+        :annotation: 380
 
    * .. autodata:: mapscript.MS_TOKEN_BINDING_INTEGER
-        :annotation: 371
+        :annotation: 381
 
    * .. autodata:: mapscript.MS_TOKEN_BINDING_STRING
-        :annotation: 372
+        :annotation: 382
 
    * .. autodata:: mapscript.MS_TOKEN_BINDING_TIME
-        :annotation: 373
+        :annotation: 383
 
    * .. autodata:: mapscript.MS_TOKEN_BINDING_SHAPE
-        :annotation: 374
+        :annotation: 384
 
    * .. autodata:: mapscript.MS_TOKEN_BINDING_MAP_CELLSIZE
-        :annotation: 375
+        :annotation: 385
 
    * .. autodata:: mapscript.MS_TOKEN_BINDING_DATA_CELLSIZE
-        :annotation: 376
+        :annotation: 386

--- a/en/mapscript/mapscript-api/constants/version.rst
+++ b/en/mapscript/mapscript-api/constants/version.rst
@@ -6,14 +6,14 @@ Version
 .. hlist::
    :columns: 3
     
-   * .. autodata:: mapscript.MS_VERSION_REV
+   * .. autodata:: mapscript.MS_VERSION_MINOR
         :annotation: 0
 
-   * .. autodata:: mapscript.MS_VERSION_MAJOR
-        :annotation: 7
+   * .. autodata:: mapscript.MS_VERSION_REV
+        :annotation: 1
 
-   * .. autodata:: mapscript.MS_VERSION_MINOR
-        :annotation: 7
+   * .. autodata:: mapscript.MS_VERSION_MAJOR
+        :annotation: 8
 
    * .. autodata:: mapscript.MS_VERSION_NUM
-        :annotation: 70700
+        :annotation: 80001

--- a/en/mapscript/mapscript-api/functions.rst
+++ b/en/mapscript/mapscript-api/functions.rst
@@ -25,5 +25,3 @@
     mapscript.msResetErrorList
     mapscript.msSaveImage
     mapscript.msSetup
-    mapscript.shapeObj_fromWKT
-    mapscript.value

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 alabaster==0.7.13
 sphinx==7.2.2
 sphinx-removed-in==0.2.1
-mapscript=8.0.1
+mapscript==8.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 alabaster==0.7.13
 sphinx==7.2.2
 sphinx-removed-in==0.2.1
+mapscript=8.0.1

--- a/scripts/mapscript-docs/ReadMe.rst
+++ b/scripts/mapscript-docs/ReadMe.rst
@@ -5,26 +5,23 @@ This folder contains scripts to regenerate various MapScript documentation pages
 using the Python MapScript module. When there are new classes, global functions, or
 constant values these scripts should be re-run.
 
-To run first set-up a virtual environment (code here is for Windows, but Linux commands
+To run first set-up a virtual environment (code here is for Windows using PowerShell, but Linux commands
 should be similar):
 
-.. code-block:: bat
+.. code-block:: ps1
 
-    C:\Python38\Scripts\virtualenv.exe C:\VirtualEnvs\mapscript-docs-update
-    C:\VirtualEnvs\mapscript-docs-update\Scripts\activate
-    python -m pip install pip -U
+    C:\Python310\Scripts\virtualenv C:\VirtualEnvs\mapscript-docs-update
+    C:\VirtualEnvs\mapscript-docs-update\Scripts\activate.ps1
 
-    pip install --index-url https://test.pypi.org/simple/ mapscript==7.7.1
-    REM following maybe required if there is a clash of sqlite versions
-    copy C:\MapServer\bin\sqlite3.dll C:\VirtualEnvs\mapscript-docs-update\Lib\site-packages\mapscript
-    SET PATH=C:\MapServer\bin;%PATH%
-    SET MAPSERVER_DLL_PATH=C:\MapServer\bin
-    cd /D mapserver/scripts/mapscript-docs
+    pip install mapscript==8.0.1
+    $env:Path = "C:\MapServer\bin;" + $env:Path
+    $env:MAPSERVER_DLL_PATH="C:\MapServer\bin"
+    cd D:\GitHub\mapserver_docs\scripts\mapscript-docs
 
 Updating the MapScript Constants
 --------------------------------
 
-.. code-block:: bat
+.. code-block:: ps1
 
     python constants.py
 
@@ -36,10 +33,10 @@ For DOT language see http://www.graphviz.org/doc/info/attrs.html
 See also https://stackoverflow.com/questions/1494492/graphviz-how-to-go-from-dot-to-a-graph
 For Entity Relationship diagram example see https://graphviz.readthedocs.io/en/stable/examples.html#er-py
 
-.. code-block:: bat
+.. code-block:: ps1
 
     pip install pydot
-    SET PATH=C:\Program Files (x86)\Graphviz2.38\bin;%PATH%
+    $env:Path = "C:\Program Files (x86)\Graphviz2.38\bin;" + $env:Path
     python diagrams.py
 
 Updating MapScript Objects
@@ -47,13 +44,13 @@ Updating MapScript Objects
 
 This script updates the include files listing the functions and classes available in MapScript.
 
-.. code-block:: bat
+.. code-block:: ps1
 
     python objects.py
 
 Run all scripts:
 
-.. code-block:: bat
+.. code-block:: ps1
 
     python constants.py
     python diagrams.py

--- a/scripts/mapscript-docs/constants.py
+++ b/scripts/mapscript-docs/constants.py
@@ -88,6 +88,9 @@ patterns = {
     "parse": "MS_PARSE_TYPE",
     "dbf-fields": "FT",
     "projections": "wkp_",
+    "scalebar": "MS_SCALEBAR_",
+    "config": "MS_CONFIG_",
+    "legend": "MS_LEGEND_"
 }
 
 constants = [p for p in props if isinstance(getattr(mapscript, p), int)]
@@ -179,6 +182,7 @@ for p in constants:
             "MS_UNUSED_2",
             "MS_UVRASTER",
             "MS_IDW",
+            "MS_FLATGEOBUF",
         ]:
             enumerations["connection"].append((val, p))
 


### PR DESCRIPTION
- Re-run `constants.py` file to add new constants to the API docs pages. 
- Add mapscript to requirements as mentioned in #836, and remove missing function pages. 
- Update ReadMe to use PowerShell rather than Windows CMD. 