### PR TITLE
fix: include information on wgs84boundingbox parameter in mapcache doc

### DIFF
--- a/en/mapcache/config.txt
+++ b/en/mapcache/config.txt
@@ -526,13 +526,22 @@ the client in a given *format*.
       <!-- metadata
 
            Optional metadata tags used for responding to GetCapabilities
-           requests. You can put anything here, but only the title, abstract and
+           requests. You can put anything here, but only the title, abstract, wgs84boundingbox and
            keywords tags are currently used to populate the GetCapabilities
            document.
       -->
       <metadata>
          <title>vmap0 map</title>
          <abstract>blabla</abstract>
+         <!-- Sets the extent of the tileset. Used by GIS to zoom to the layer. Order is Lon/Lat (example extent 
+         is the region around London). Will be translated 
+         to 
+         <ows:WGS84BoundingBox>
+            <ows:LowerCorner>-0.837 51.058</ows:LowerCorner>
+            <ows:UpperCorner>0.57 51.834</ows:UpperCorner>
+         </ows:WGS84BoundingBox> 
+         -->
+         <wgs84boundingbox>-0.837 51.058 0.57 51.834</wgs84boundingbox>
          <keywords>
             <keyword>foo</keyword>
             <keyword>bar</keyword>


### PR DESCRIPTION
The [Mapcache Documentation](https://mapserver.org/sq/mapcache/config.html) does not mention the possibility to add a 
`wgs84boundingbox` XML-Tag to a `tileset`'s `metadata`. The capability  is mentioned in this [Mail-Thread](https://lists.osgeo.org/pipermail/mapserver-users/2012-May/072249.html).  It is (propably) parsed [here](https://github.com/MapServer/mapcache/blob/0b85061c673ade7a0890759105c7db79a21af87d/lib/configuration_xml.c#L829C86-L829C86) and rendered to XML [here](https://github.com/MapServer/mapcache/blob/0b85061c673ade7a0890759105c7db79a21af87d/lib/service_wmts.c#L370)

I'll take the opportunity to thank you for your amazing work on both UMN Mapserver and Mapcache.