### PR TITLE
Use annotated mapscript library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 alabaster==0.7.13
 sphinx==7.2.5
 sphinx-removed-in==0.2.1
-mapscript==8.0.1
+--extra-index-url https://test.pypi.org/simple/
+mapscript==8.1.0


### PR DESCRIPTION
As part of the changes in #839 I incorrectly used a mapscript library without the autogenerated comments. 
This update uses a version of MapScript from test.pypi that has comments so the MapScript documentation is correctly generated. 
I can correct this for the next MapServer release, until then the test version will work. 