### PR TITLE
Adjust debugging MapFile doc about systemd private tmp dir

### DIFF
--- a/en/optimization/debugging.txt
+++ b/en/optimization/debugging.txt
@@ -62,6 +62,11 @@ messages from MapServer.  You can pass the following values to
   environment variable always requires an absolute path since there would
   be no mapfile to make the path relative to.
 
+  Note that on Linux, if your are using a path from the `/tmp` directory
+  like `/tmp/ms_error.txt`, the log will actually output in
+  (`private directory provided by systemd <https://systemd.io/TEMPORARY_DIRECTORIES/>`__)
+  generated for the web server used (like Apache).
+
 **stderr**
   Use this to send MapServer's debug messages to the Web server's log
   file (i.e. "standard error").  If you are using Apache, your debug


### PR DESCRIPTION
When working on a Linux OS, debugging a MapFile while using the `/tmp` directory can be misleading for people who are not aware about systemd private directory security, i.e. putting `/tmp/ms_error.txt` in the MapFile does not actually output the log at that exact location on your OS system.  It outputs it in a private directory generated by systemd for the service used (in my case, it was Apache).

So, this patch is about documenting this to avoid people that were unaware of that (like me) to fall in that trap again in the future.