### PR TITLE
Update TRANSPARENT keywords

### DIFF
--- a/en/mapfile/legend.txt
+++ b/en/mapfile/legend.txt
@@ -140,5 +140,5 @@ TEMPLATE [filename]
 TRANSPARENT [on|off]
 
     By default, a legend will inherit the same transparency setting as the 
-    map :ref:OUTPUTFORMAT. However, this flag can be used to override this setting, 
+    map :ref:`OUTPUTFORMAT`. However, this flag can be used to override this setting, 
     allowing, for example, a transparent legend to be embedded in a non-transparent map.

--- a/en/mapfile/legend.txt
+++ b/en/mapfile/legend.txt
@@ -138,8 +138,7 @@ TEMPLATE [filename]
    :name: mapfile-legend-transparent
     
 TRANSPARENT [on|off]
-    .. deprecated:: 4.6
 
     Should the background color for the legend be transparent. 
-    This flag is now deprecated in favor of declaring transparency within 
-    :ref:`OUTPUTFORMAT` declarations. Default is off.
+    This flag can be different from from the :ref:`OUTPUTFORMAT` TRANSPARENT setting, allowing
+    a transparent legend embedded in an non-transparent map. Default is off.

--- a/en/mapfile/legend.txt
+++ b/en/mapfile/legend.txt
@@ -140,5 +140,5 @@ TEMPLATE [filename]
 TRANSPARENT [on|off]
 
     Should the background color for the legend be transparent. 
-    This flag can be different from from the :ref:`OUTPUTFORMAT` TRANSPARENT setting, allowing
+    This flag can be different from the :ref:`OUTPUTFORMAT` TRANSPARENT setting, allowing
     a transparent legend embedded in an non-transparent map. Default is off.

--- a/en/mapfile/legend.txt
+++ b/en/mapfile/legend.txt
@@ -139,6 +139,6 @@ TEMPLATE [filename]
     
 TRANSPARENT [on|off]
 
-    Should the background color for the legend be transparent. 
-    This flag can be different from the :ref:`OUTPUTFORMAT` TRANSPARENT setting, allowing
-    a transparent legend embedded in an non-transparent map. Default is off.
+    By default, a legend will inherit the same transparency setting as the 
+    map :ref:OUTPUTFORMAT. However, this flag can be used to override this setting, 
+    allowing, for example, a transparent legend to be embedded in a non-transparent map.

--- a/en/mapfile/scalebar.txt
+++ b/en/mapfile/scalebar.txt
@@ -224,11 +224,10 @@ STYLE [integer]
     Chooses the scalebar style. Valid styles are 0 and 1.
 
 TRANSPARENT [on|off]
-    .. versionremoved:: 8.0
 
-    Should the background color for the scalebar be transparent. This flag is 
-    now deprecated in favor of declaring transparency within :ref:`OUTPUTFORMAT`
-    declarations. Default is off.
+    Should the background color for the scalebar be transparent. This flag 
+    can be different from from the :ref:`OUTPUTFORMAT` TRANSPARENT setting, allowing
+    a transparent scalebar embedded in an non-transparent map. Default is off.
     
 .. index::
    pair: SCALEBAR; UNITS

--- a/en/mapfile/scalebar.txt
+++ b/en/mapfile/scalebar.txt
@@ -226,7 +226,7 @@ STYLE [integer]
 TRANSPARENT [on|off]
 
     Should the background color for the scalebar be transparent. This flag 
-    can be different from from the :ref:`OUTPUTFORMAT` TRANSPARENT setting, allowing
+    can be different from the :ref:`OUTPUTFORMAT` TRANSPARENT setting, allowing
     a transparent scalebar embedded in an non-transparent map. Default is off.
     
 .. index::

--- a/en/mapfile/scalebar.txt
+++ b/en/mapfile/scalebar.txt
@@ -226,7 +226,7 @@ STYLE [integer]
 TRANSPARENT [on|off]
 
     By default, a scalebar will inherit the same transparency setting as the 
-    map :ref:OUTPUTFORMAT. However, this flag can be used to override this setting, 
+    map :ref:`OUTPUTFORMAT`. However, this flag can be used to override this setting, 
     allowing, for example, a transparent scalebar to be embedded in a non-transparent map.
 
 .. index::

--- a/en/mapfile/scalebar.txt
+++ b/en/mapfile/scalebar.txt
@@ -225,10 +225,10 @@ STYLE [integer]
 
 TRANSPARENT [on|off]
 
-    Should the background color for the scalebar be transparent. This flag 
-    can be different from the :ref:`OUTPUTFORMAT` TRANSPARENT setting, allowing
-    a transparent scalebar embedded in an non-transparent map. Default is off.
-    
+    By default, a scalebar will inherit the same transparency setting as the 
+    map :ref:OUTPUTFORMAT. However, this flag can be used to override this setting, 
+    allowing, for example, a transparent scalebar to be embedded in a non-transparent map.
+
 .. index::
    pair: SCALEBAR; UNITS
    :name: mapfile-scalebar-units


### PR DESCRIPTION
As noted in the thread at https://lists.osgeo.org/pipermail/mapserver-dev/2023-October/017023.html - the SCALEBAR and LEGEND TRANSPARENT keywords are still required to create transparent scalebars and legends on non-transparent maps. 