### PR TITLE
Only deploy the active branch-8-0 to mapserver.org

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
           
           touch ./build/html/.nojekyll   
           
-          if [ "${{ github.event_name }}" = "push" ] && [ "$GIT_BRANCH" = "main" ]; then
+          if [ "${{ github.event_name }}" = "push" ] && [ "$GIT_BRANCH" = "branch-8-0" ]; then
             # get the short commit tag
             sha=$(git rev-parse --short ${{ github.sha }})          
             echo "publish website using $GIT_BRANCH branch and commit $sha"


### PR DESCRIPTION
This ensures https://mapserver.org/ is only updated by changes to the active `branch8-0`. 
The GHA logic was ported from TravisCI, but it seems changes to the main branch were also causing the website to update - see the history of https://github.com/MapServer/mapserver.github.io/commits/master/ and for example this pull request to main that was deployed - https://github.com/MapServer/MapServer-documentation/commit/9e8efe092f009540017b7c8e7edb69668a6d8ca8

Typically backports were then also applied which re-deployed branch-8-0 on top of this. 

This pull request ensures only merges to branch-8-0 get deployed. 