### PR TITLE
mapcache: custom Cache-Control HTTP header directive documentation

### DIFF
--- a/en/mapcache/config.txt
+++ b/en/mapcache/config.txt
@@ -613,6 +613,26 @@ the client in a given *format*.
       -->
       <auto_expire>86400</auto_expire>
 
+      <!-- cache-control
+
+            Optional Cache-Control HTTP header directives.
+            These directives apply to all tiled responses (TMS, WMTS, ...).
+            The "max-age=" directive is always set based on the <expires>
+            and <auto_expire> configuration parameters.
+
+            The specified value is passed verbatim without any validation whatsoever.
+            Please refer to the HTTP header documentation for valid usage:
+            https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
+
+            For instance, for historic maps that are not expected to change,
+            set the <expires> option to "31556926" (one year) and <cache-control>
+            to "immutable" (do not check until expired). On clients supporting
+            the "immutable" directive (e.g., Firefox), data will be loaded
+            directly from a local cache without issuing any requests
+            to the server to revalidate it.
+      -->
+      <cache-control>immutable</cache-control>
+
       <!-- dimensions
 
            Optional dimensions that should be cached.


### PR DESCRIPTION
Documentation of tileset Cache-Control HTTP header directive merged in PR https://github.com/MapServer/mapcache/pull/329