### PR TITLE
Add JQuery to fix broken Service Providers page

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -49,7 +49,8 @@ sys.path.append(os.path.abspath('.'))
 #extensions = ['labels' ,'rst2pdf.pdfbuilder']
 #extensions = ['labels', 'sphinxcontrib.spelling']
 
-extensions = ['labels', 'sphinx_removed_in', 'sphinx.ext.autodoc', 'sphinx.ext.autosummary', 'sphinx.ext.viewcode']
+extensions = ['labels', 'sphinx_removed_in', 'sphinx.ext.autodoc', 'sphinx.ext.autosummary', 'sphinx.ext.viewcode'
+              , 'sphinxcontrib.jquery']
 
 autosummary_generate = True # when True create a page for each mapscript class
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 alabaster==0.7.16
 sphinx==7.2.6
 sphinx-removed-in==0.2.1
+sphinxcontrib-jquery==4.1
 --extra-index-url https://test.pypi.org/simple/
 mapscript==8.1.0


### PR DESCRIPTION
The Service Providers page is currently broken (in terms of layout and random ordering) as JQuery no longer seems to be present in the deployed docs at https://mapserver.org/community/service_providers.html#service-providers

`Uncaught ReferenceError: $ is not defined`

![image](https://github.com/MapServer/MapServer-documentation/assets/490840/b336a599-9e69-4b76-8319-05b4aa6da385)

This pull request adds back JQuery using the Sphinx plugin https://pypi.org/project/sphinxcontrib-jquery/ which fixes the issue. 


