### PR TITLE
fixed typo for Celsius in the WCS_format page (s/Celcius/Celsius/)

### DIFF
--- a/en/ogc/wcs_format.txt
+++ b/en/ogc/wcs_format.txt
@@ -11,7 +11,7 @@
 :Contact:      nbarker at ittvis.com
 :Author:       Gail Millin
 :Contact:      nbarker at ittvis.com
-:Last Updated: 2019-11-21
+:Last Updated: 2024-02-28
 
 
 .. contents::
@@ -402,7 +402,7 @@ and the actual layer
             "wcs_native_format" "application/x-grib2"
             "wcs_band_names" "Temperature_2m"
             "Temperature_2m_band_interpretation" "interp"
-            "Temperature_2m_band_uom" "Celcius"
+            "Temperature_2m_band_uom" "Celsius"
             "Temperature_2m_band_definition"       "Temperature at 2m above ground"
             "Temperature_2m_band_description"      "Temperature at 2m above ground"
             "Temperature_2m_interval" "-100 100"


### PR DESCRIPTION
fixed typo for Celsius in the WCS_format page (s/Celcius/Celsius/)