### PR TITLE
Remove mapscript docs referencing 8.4 functionality from 8.2 branch

### DIFF
--- a/en/mapscript/mapscript-api/constants/compop.rst
+++ b/en/mapscript/mapscript-api/constants/compop.rst
@@ -89,15 +89,3 @@ Compop
 
    * .. autodata:: mapscript.MS_COMPOP_INVERT_RGB
         :annotation: 27
-
-   * .. autodata:: mapscript.MS_COMPOP_HSL_HUE
-        :annotation: 28
-
-   * .. autodata:: mapscript.MS_COMPOP_HSL_LUMINOSITY
-        :annotation: 29
-
-   * .. autodata:: mapscript.MS_COMPOP_HSL_SATURATION
-        :annotation: 30
-
-   * .. autodata:: mapscript.MS_COMPOP_HSL_COLOR
-        :annotation: 31


### PR DESCRIPTION
Documentation builds for the 8.2 branch are reporting the following errors:

```
AttributeError: module 'mapscript' has no attribute 'MS_COMPOP_HSL_HUE'
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.10.12/x64/lib/python3.10/site-packages/sphinx/ext/autodoc/importer.py", line 210, in import_object
    obj = attrgetter(obj, mangled_name)
...
```

I think this is due to https://github.com/MapServer/MapServer-documentation/pull/914 being merged in May 2024, prior to the 8.2 documentation branch being created. When the branch was created from `main` this pull request was included. 

The references to 8.4 functionality are live at https://www.mapserver.org/mapfile/composite.html (which isn't an issue). This pull requests fixes the 8.2 branch to avoid the above Python errors. 

