### PR TITLE
Clean repository when all languages are rebuilt

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,9 +28,9 @@ jobs:
           mkdir -p ~/.ssh
           echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
-          echo -e "Host *\n\tStrictHostKeyChecking no\n" > ~/.ssh/config  
+          echo -e "Host *\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
 
-          touch ./build/html/.nojekyll   
+          touch ./build/html/.nojekyll
 
           # get the short commit tag
           sha=$(git rev-parse --short ${{ github.sha }})

--- a/scripts/ci_deploy_website.sh
+++ b/scripts/ci_deploy_website.sh
@@ -4,26 +4,36 @@ builddir=$1
 destdir=$2
 sha=$3
 
+# check the PDF was created and upload to https://mapserver.org/pdf/MapServer.pdf
 if [ -f $builddir/latex/en/MapServer.pdf ]; then
   set -x
   scp $builddir/latex/en/MapServer.pdf mapserver@mapserver.org:/var/www/mapserver.org/pdf/
   set +x
 fi
 
-
 if [ ! -d $destdir/mapserver.github.io ]; then
   git clone git@github.com:mapserver/mapserver.github.io.git $destdir/mapserver.github.io
 fi
 
+# remove all previous files in the repo if [build_translations]
+# is in the commit message
+git log -n1 | grep -q "\\[build_translations\\]"
+
+if [[ $? -eq 0 ]]; then
+    rm -rf "$destdir/mapserver.github.io"/*
+fi
+
+# copy in the newly created files
 cd $builddir/html
 cp -rf * $destdir/mapserver.github.io
 
 cd $destdir/mapserver.github.io
+
+# restore README.md from the last commit
+git checkout HEAD -- README.md
+
 git config user.email "mapserverbot@mapserver.bot"
 git config user.name "MapServer deploybot"
-
-#rm -rf _sources */_sources
-#rm -rf .doctrees */.doctrees */.buildinfo
 
 git add -A
 git commit -m "update with results of commit https://github.com/mapserver/MapServer-documentation/commit/$sha"

--- a/scripts/ci_deploy_website.sh
+++ b/scripts/ci_deploy_website.sh
@@ -29,8 +29,9 @@ cp -rf * $destdir/mapserver.github.io
 
 cd $destdir/mapserver.github.io
 
-# restore README.md from the last commit
+# restore README.md and .nojekyll from the last commit
 git checkout HEAD -- README.md
+git checkout HEAD -- .nojekyll
 
 git config user.email "mapserverbot@mapserver.bot"
 git config user.name "MapServer deploybot"


### PR DESCRIPTION
When docs are built and pushed to https://github.com/MapServer/mapserver.github.io/ old HTML files are never removed.

There are several published pages which have been removed from https://github.com/MapServer/MapServer-documentation/ that are still online. For example:

- https://www.mapserver.org/mapscript/mapscript.html
- https://mapserver.org/previousversions.html
- https://mapserver.org/zh_cn/mapfile/map.html
- https://www.mapserver.org/mapfile/labelencoding.html

This pull request adds a step to delete all the files from the https://github.com/MapServer/mapserver.github.io/ repo if a pull request includes `[build_translations]` in the commit message. This tag is already used to trigger rebuilds of all languages. 

We can only remove all files when rebuilding all languages, otherwise when building just `en` all the language subfolders (`ar`, `fr` etc.) would be removed.

I've tested this on my own forks - see https://github.com/geographika/MapServer-documentation/actions
Note the `uk` and `zh_cn` folders are removed completely (they haven't been build for several years):

https://github.com/MapServer/mapserver.github.io/tree/master/uk
https://github.com/MapServer/mapserver.github.io/tree/master/zh_cn

The cleaned repository goes from 1.2 GB and 32,141 files to 810 MB and 28,979 files. 
You can compare before and after the clean-up by looking at https://github.com/MapServer/mapserver.github.io/ and https://github.com/geographika/mapserver.github.io

The only files not generated by Sphinx README.md and .nojekyll are restored after the repo is cleaned. 





