### PR TITLE
Rebuild translated MapServer documentation

### DIFF
--- a/en/development/documentation.txt
+++ b/en/development/documentation.txt
@@ -29,6 +29,7 @@ website is then automatically updated on each merged pull request.
    
     The live website is actually built automatically through a `GitHub workflow <https://github.com/MapServer/MapServer-documentation/blob/main/.github/workflows/build.yml>`__, 
     triggered by each push to the live branch.  See the `build history <https://github.com/MapServer/MapServer-documentation/actions/workflows/build.yml>`__.
+    The different language documentation sites are rebuilt when a commit message includes ``[build_translations]``.
 
 GitHub Notes
 ------------
@@ -543,7 +544,7 @@ Then push po files to transifex (you can use -l flags to filter the language)::
 When committing your update, add [build_pdf] or [build_translations] in order to 
 build pdf and/or translation to the webserver.
 
-**Knonw issues:**
+**Known issues:**
  
 * when downloading po files to local dir, if the file exists it won't be 
   updated. At this moment we should remove all po files before downloading.


### PR DESCRIPTION
Adding `[build_translations]` in the commit message should trigger a rebuild of the translated documents. See #966. 