### PR TITLE
Document MAP_RESOLUTION WMS vendor specific parameter

### DIFF
--- a/en/mapfile/map.txt
+++ b/en/mapfile/map.txt
@@ -291,7 +291,7 @@ DEFRESOLUTION [double]
     symbology.  Default is 72. Minimum is 10 and maximum is 1000.
      
     Used to automatically scale the symbology when :ref:`RESOLUTION
-    <resolution-parameter>` is changed, so the map maintains the same
+    <mapfile-map-resolution>` is changed, so the map maintains the same
     look at each resolution.  The scale factor is `RESOLUTION` /
     `DEFRESOLUTION`.
 
@@ -451,10 +451,9 @@ NAME [name]
 .. index::
    pair: MAP; RESOLUTION
    :name: mapfile-map-resolution
-    
-.. _resolution-parameter:
 
-RESOLUTION [double] Sets the pixels per inch for output, only affects
+RESOLUTION [double]
+    Sets the pixels per inch for output, only affects
     scale computations.  Default is 72. Minimum is 10 and maximum is 1000.
 
 .. index::

--- a/en/ogc/wms_server.txt
+++ b/en/ogc/wms_server.txt
@@ -2144,6 +2144,25 @@ Vendor specific WMS parameters
      The angle value is in degrees clockwise. 
 
 .. index::
+   triple: WMS; Vendor specific parameters; bbox_pixel_is_point
+
+**bbox_pixel_is_point**
+
+- If this parameter is "TRUE", MapServer will treat the BBOX received in WMS
+  GetMap requests as if it was provided in pixel_is_point mode. Essentially
+  disabling the conversion from pixel_is_area (WMS model) to pixel_is_point that
+  is present in mapwms.c for that specific mapfile.
+
+.. index::
+   triple: WMS; Vendor specific parameters; map_resolution
+
+**map_resolution**
+
+- Set this parameter to change the Map :ref:`RESOLUTION <mapfile-map-resolution>`.
+  MapServer uses a default screen resolution of 72 DPI. For high-resolution screens,
+  pass this parameter to ensure fonts and symbols appear at the correct size.
+
+.. index::
    triple: WMS; Vendor specific parameters; radius
 
 **radius**
@@ -2155,15 +2174,8 @@ Vendor specific WMS parameters
   - The special value `bbox` that will change the query into a bbox
     query based on the bbox given in the request parameters.
 
-**bbox_pixel_is_point**
-
-- If this parameter is "TRUE", MapServer will treat the BBOX received in WMS
-  GetMap requests as if it was provided in pixel_is_point mode. Essentially
-  disabling the conversion from pixel_is_area (WMS model) to pixel_is_point that
-  is present in mapwms.c for that specific mapfile.
-   
 .. index::
-   pair: WMS; Cascading requests
+   pair: WMS; HTTP status error codes
 
 HTTP status error codes
 -----------------------
@@ -2195,6 +2207,9 @@ to return HTTP 4xx or 5xx status codes in case of error.
       MS_WMS_ERROR_STATUS_CODE "ON"
     END
   END
+
+.. index::
+   pair: WMS; Cascading requests
 
 Cascading WMS Requests
 ----------------------


### PR DESCRIPTION
Documents the vendor MAP_RESOLUTION parameter for MapServer WMS. 
As discussed in https://github.com/mapserver/mapserver/issues/5350

It is also used by OpenLayers - see discussion at https://github.com/openlayers/openlayers/issues/14391 if [serverType](https://openlayers.org/en/latest/apidoc/module-ol_source_wms.html#~ServerType) is set and `hidpi` is set to `true`.

Pull requests also fixes some index links. 
