### PR TITLE
Remove references to USE_POINT_Z_M

### DIFF
--- a/en/ogc/wfs_server.txt
+++ b/en/ogc/wfs_server.txt
@@ -72,7 +72,7 @@ certain libraries:
 - GDAL/OGR: I/O support libraries. Version 1.6.0 or greater is required.
 
 Please see the MapServer :ref:`UNIX Compilation and Installation HowTo
-<unix>` for detailed instructions on compiling mapserver with support
+<unix>` for detailed instructions on compiling MapServer with support
 for these libraries and features.  For Windows users, the `MS4W`_
 installer comes ready to serve both WFS and WMS.
 
@@ -746,7 +746,7 @@ Web Object Metadata
 **wfs_features_cache_size**
   (Optional, since MapServer 7.2) Maximum amount of RAM allowed to cache
   features during the first query pass, so as not to be asked again to
-  the datasource when geneating the GML or OGR output.
+  the datasource when generating the GML or OGR output.
   If wfs_features_cache_count   is also set, the most limiting will be honoured.
   By default the value is in bytes, unless the " MB" suffix is specified.
   Note: this is an advanced setting.
@@ -1030,8 +1030,7 @@ Layer Object
   a mix of geometry types, and "None" is sometimes suitable for layers without
   geometry.  Note that layers which are a mix of polygon and multipolygon 
   would normally have to be described as "Geometry".  To produce 2.5D output
-  append "25D" to the geometry type (ie. "Polygon25D").   Note that Z values
-  are only carried by MapServer if built with USE_POINT_Z_M support.
+  append "25D" to the geometry type (i.e. "Polygon25D").
 
   ::
 
@@ -1259,7 +1258,7 @@ Layer Object
    triple: WFS; METADATA; wfs_getfeature_formatlist    
 
 **wfs_getfeature_formatlist**
-  (Optional) Comma-separted list of formats that should be valid for a
+  (Optional) Comma-separated list of formats that should be valid for a
   GetFeature request.  If defined, only these formats are advertised
   in the Capabilities document.
 
@@ -1353,7 +1352,7 @@ Layer Object
 
 **wfs_srs**
   If there is no SRS defined at the top-level in the mapfile then this
-  SRS will be used to advertize this feature type (layer) in the
+  SRS will be used to advertise this feature type (layer) in the
   capabilities. See the note about the SRS rules in WFS.
 
 .. index:: 

--- a/en/output/ogr_output.txt
+++ b/en/output/ogr_output.txt
@@ -243,8 +243,7 @@ primarily intended to support WFS.
   a mix of geometry types, and "None" is sometimes suitable for layers without
   geometry.  Note that layers which are a mix of polygon and multipolygon 
   would normally have to be described as "Geometry".  To produce 2.5D output
-  append "25D" to the geometry type (ie. "Polygon25D").   Note that Z values
-  are only carried by MapServer if built with USE_POINT_Z_M support.
+  append "25D" to the geometry type (i.e. "Polygon25D").
 
   ::
 
@@ -305,7 +304,7 @@ types (ie. polygons and multipolygons) the geometry type should be set to
 
 In order 2.5D support (geometries with Z coordinates) to be enabled, the "25D"
 suffix must be add to the value of the "ows_geomtype" metadata item
-(i.e. "Polygon25D"), and MapServer must be built with USE_POINT_Z_M support.
+(i.e. "Polygon25D").
 
 .. note::
    Empty geometries are supported from the MapServer 8.0 release. 


### PR DESCRIPTION
This build flag was removed in MapServer 8.0 (see https://github.com/MapServer/MapServer/pull/6263), and so Z values are now always available.

A few other typos fixed in the surrounding docs. 