### PR TITLE
Add PROCESSING CLASSIFY_SCALED directive

### DIFF
--- a/en/input/raster.txt
+++ b/en/input/raster.txt
@@ -420,7 +420,24 @@ are supported in MapServer 4.0 and newer.
     ::
   
        PROCESSING "BANDS=4,2,1"
-      
+
+.. index::
+   triple: LAYER; PROCESSING; CLASSIFY_SCALED
+
+**CLASSIFY_SCALED=YES/NO**
+    This directive (added in 7.6) allows classification to use pre-scaled raster data
+    for 16 bit rasters. In the example below data in the range 0-28
+    is stretched to the 0-255 range and then classified.
+
+    Example:
+  
+    ::
+
+       PROCESSING "SCALE=0,28"
+       PROCESSING "SCALE_BUCKETS=256"
+       PROCESSING "CLASSIFY_SCALED=TRUE"
+
+
 .. index::
    triple: LAYER; PROCESSING; COLOR_MATCH_THRESHOLD
 


### PR DESCRIPTION
`PROCESSING "CLASSIFY_SCALED=TRUE"` was added in https://github.com/MapServer/MapServer/pull/5834 to resolve https://github.com/mapserver/mapserver/issues/5830 and merged in 7.6. 