### PR TITLE
Remove RUNSUB for CLASS GROUP

### DIFF
--- a/en/mapfile/class.txt
+++ b/en/mapfile/class.txt
@@ -138,9 +138,6 @@ GROUP [string]
         ...
       END # layer
 
-    .. note::
-        |RUNSUB|
-
 .. index::
    pair: CLASS; KEYIMAGE
    :name: mapfile-class-keyimage


### PR DESCRIPTION
This is not supported by MapServer. See https://mapserver.org/cgi/runsub.html#parameters-supported.