### PR TITLE
INSPIRE view service: add section on conformance testing

### DIFF
--- a/en/ogc/inspire.txt
+++ b/en/ogc/inspire.txt
@@ -342,13 +342,42 @@ in msautotest::
        +--- TN.RailTransportNetwork.RailwayLink
        +--- TN.AirTransportNetwork.AirLink
 
+Conformance Testing
+===================
+
+`INSPIRE Validator`_ is the standard testing tool for INSPIRE web services.
+While it can be used as a standalone product, other testing frameworks like
+`GDI-DE Testsuite`_ in Germany build on it and extend it.
+
+The `INSPIRE Validator`_ contains a 'Conformance Class: View Service - WMS' test suite
+for testing WMS compliance.
+In order to make these tests pass and enforce strict compliance, you will need to
+add some extra configuration settings to the `WEB.METADATA` section::
+
+  WEB
+   METADATA
+    "ows_inspire_capabilities" "url|embed" # make this an INSPIRE service
+    ...
+    # Enable strict OGC compliance
+    "ows_compliance_mode"      "true"
+
+    # Override the default INSPIRE schemas location.
+    # Needed because the INSPIRE validator will not
+    # follow a permanent redirect from plain http://
+    # and throw an error instead.
+    "inspire_schemas_location" "https://inspire.ec.europa.eu/schemas"
+    ...
+   END
+  END
 
 .. #### rST Link Section ####
 
 .. _`European directive`: https://knowledge-base.inspire.ec.europa.eu/index_en
+.. _`GDI-DE Testsuite`: https://testsuite.gdi-de.org
 .. _`INSPIRE Technical Guidance document`: https://inspire-mif.github.io/technical-guidelines/services/view-wms/
-
 .. _`INSPIRE schemas`: https://inspire.ec.europa.eu/schemas/inspire_vs/1.0/inspire_vs.xsd
+.. _`INSPIRE Validator`: https://github.com/INSPIRE-MIF/helpdesk-validator/
+.. _`http://inspire.ec.europa.eu/schemas`: https://inspire.ec.europa.eu/schemas
 .. _`WMS INSPIRE tester`: https://github.com/neogeo-technologies/inspire_tester
 .. _document: https://web.archive.org/web/20121110042846/http://www.neogeo-online.net/blog/wp-content/uploads/2011/04/MAPSERVER_INSPIRE.pdf
 .. _`INSPIRE Metadata Implementing Rules`: https://knowledge-base.inspire.ec.europa.eu/publications/inspire-metadata-implementing-rules-technical-guidelines-based-en-iso-19115-and-en-iso-19119_en

--- a/en/ogc/inspire.txt
+++ b/en/ogc/inspire.txt
@@ -357,19 +357,24 @@ add some extra configuration settings to the `WEB.METADATA` section::
   WEB
    METADATA
     "ows_inspire_capabilities" "url|embed" # make this an INSPIRE service
-    ...
-    # Enable strict OGC compliance
-    "ows_compliance_mode"      "true"
-
-    # Override the default INSPIRE schemas location.
-    # Needed because the INSPIRE validator will not
-    # follow a permanent redirect from plain http://
-    # and throw an error instead.
-    "inspire_schemas_location" "https://inspire.ec.europa.eu/schemas"
+    "ows_compliance_mode"      "true" # Enable strict OGC compliance
     ...
    END
   END
 
+.. tip::
+    In MapServer <= 8.6.3, you also need to override the 
+    INSPIRE schema repository location, because INSPIRE 
+    validator will throw an error on the default::
+
+      WEB
+        METADATA
+	  ...
+          "inspire_schemas_location" "https://inspire.ec.europa.eu/schemas"
+	  ...
+	END
+      END
+    
 .. #### rST Link Section ####
 
 .. _`European directive`: https://knowledge-base.inspire.ec.europa.eu/index_en

--- a/en/ogc/wms_server.txt
+++ b/en/ogc/wms_server.txt
@@ -1057,7 +1057,7 @@ Web Object Metadata
   metadata) Root of the web tree where the family of OGC WMS XMLSchema
   files are located. This must be a valid URL where the actual .xsd
   files are located if you want your WMS output to validate in a
-  validating XML parser. Default is `https://schemas.opengis.net`_.
+  validating XML parser. Default is `http://schemas.opengis.net`_.
 
 
 .. index:: 
@@ -2488,7 +2488,7 @@ FAQ / Common Problems
 .. _`Symbology Encoding Implementation Specification`: https://portal.ogc.org/files/?artifact_id=16700 
 .. _`The EPSG web page`: https://epsg.org/
 .. _`https://demo.mapserver.org/cgi-bin/wms?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetCapabilities`: https://demo.mapserver.org/cgi-bin/wms?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetCapabilities
-.. _`https://schemas.opengis.net`: https://schemas.opengis.net
+.. _`http://schemas.opengis.net`: https://schemas.opengis.net
 .. _`https://proj.org/`: https://proj.org/
 .. _`http://www.maptools.org/dl/proj4-epsg.zip`: http://www.maptools.org/dl/proj4-epsg.zip
 


### PR DESCRIPTION
This PR adds some hints on how to get INSPIRE view service tests green. It also corrects the default OGC schema respository location in `wms_server.txt`.
Marked as draft because depending on whether https://github.com/MapServer/MapServer/pull/7500 is accepted this PR probably needs changes.