### PR TITLE
Gh pages builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout repository contents
@@ -21,7 +23,8 @@ jobs:
           echo "GIT_BRANCH=$(echo $GITHUB_REF | cut -d '/' -f 3)" >> $GITHUB_ENV
           ./scripts/ci_build_docs.sh
 
-      - name: After success steps
+      # Deploy release branch to mapserver.github.io
+      - name: Deploy to mapserver.github.io
         if: ${{ success() && github.event_name == 'push' && github.repository == 'MapServer/MapServer-documentation' && github.ref_name == 'branch-8-6' }}
         run: |
           # setup the SSH key
@@ -36,3 +39,11 @@ jobs:
           sha=$(git rev-parse --short ${{ github.sha }})
           echo "publish website using $GIT_BRANCH branch and commit $sha"
           ./scripts/ci_deploy_website.sh build /tmp $sha
+
+      # Deploy main branch to gh-pages branch (same repo)
+      - name: Deploy to gh-pages
+        if: ${{ success() && github.event_name == 'push' && github.repository == 'MapServer/MapServer-documentation' && github.ref_name == 'main' }}
+        run: |
+          sha=$(git rev-parse --short ${{ github.sha }})
+          echo "Publishing main branch (commit $sha) to gh-pages"
+          ./scripts/ci_deploy_gh_pages.sh build $sha ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/ci_deploy_gh_pages.sh
+++ b/scripts/ci_deploy_gh_pages.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Deploys the main branch HTML build output to the gh-pages branch of the
+# MapServer-documentation repo. Called from build.yml when a push to main
+# is detected
+
+builddir=$1
+sha=$2
+github_token=$3
+
+git config user.email "mapserverbot@mapserver.bot"
+git config user.name "MapServer deploybot"
+
+git clone --no-checkout --depth=1 \
+  https://x-access-token:${github_token}@github.com/mapserver/MapServer-documentation.git \
+  /tmp/MapServer-documentation
+
+cd /tmp/MapServer-documentation
+git checkout -B gh-pages
+
+# delete existing files
+git rm -r * --quiet || true
+
+# add in the new build files
+cp -rf "$builddir/html/"* .
+touch .nojekyll
+
+git add -A
+git commit -m "update with results of commit https://github.com/mapserver/MapServer-documentation/commit/$sha" --quiet || echo "Nothing to commit"
+git push origin gh-pages --force


### PR DESCRIPTION
Adds back the main dev pages (setup in #610 and lost in #862 during migration to GHAs). 

This will push a copy of the main docs output into a gh-pages branch which can then be made accessible at https://mapserver-documentation.github.io/