### PR TITLE
Add CGI_CONTEXT_URL warning and remove duplicated docs

### DIFF
--- a/en/cgi/mapcontext.txt
+++ b/en/cgi/mapcontext.txt
@@ -15,7 +15,7 @@ following syntax:
 
     http://localhost/mapserver.cgi?MODE=map&MAP=/path/to/mapfile.map&CONTEXT=
                          /path/to/contextfile.xml&LAYERS=layer_name1 layers_name2 
-   
+
 .. note::
 
     All layers created from a context file have their status set to ON. To be
@@ -36,21 +36,33 @@ accessing a local context file:
 
 Due to security concerns loading a file from a URL is disabled by default. To 
 enable this functionality, the user needs to set a CONFIG parameter called 
-CGI_CONTEXT_URL in the default map file that will allow this functionality. 
+``CGI_CONTEXT_URL`` in the default map file that will allow this functionality. 
 Here is an example of a map file with the CONFIG parameter:
 
 ::
 
-    # Start of map file
-    NAME DEMO
-    STATUS ON
-    SIZE 400 300
-    EXTENT -2200000 -712631 3072800 3840000
-    UNITS METERS
-    IMAGECOLOR 255 255 255
-    IMAGETYPE png
-    CONFIG "CGI_CONTEXT_URL" "1"
+    MAP
+        NAME DEMO
+        STATUS ON
+        SIZE 400 300
+        EXTENT -2200000 -712631 3072800 3840000
+        UNITS METERS
+        IMAGECOLOR 255 255 255
+        IMAGETYPE png
+        CONFIG "CGI_CONTEXT_URL" "1"
     ...
+
+.. warning::
+
+    ``CGI_CONTEXT_URL`` is disabled by default. Enabling this option allows
+    MapServer to load remote context documents specified through the
+    ``CONTEXT`` CGI parameter and may result in server-side requests to
+    URLs contained in those documents.
+
+    Only enable this option when context documents come from trusted
+    sources. Where possible, outbound network access from the MapServer
+    host should be limited (for example through firewall or network policy
+    rules) to trusted services.
 
 Default Map File
 ----------------
@@ -68,24 +80,25 @@ required parameters:
 
 ::
 
-    NAME CGI-CONTEXT-DEMO
-    STATUS ON
-    SIZE 400 300
-    EXTENT -2200000 -712631 3072800 3840000
-    UNITS METERS
-    IMAGECOLOR 255 255 255
-    IMAGETYPE png
-    #
-    # Start of web interface definition
-    #
-    WEB
-      MINSCALE 2000000
-      MAXSCALE 50000000
-    #
-    # On Windows systems, /tmp and /tmp/ms_tmp/ should be created at the root 
-    # of the drive where the .MAP file resides.
-    #
-      IMAGEPATH "/ms4w/tmp/ms_tmp/" 
-      IMAGEURL "/ms_tmp/"
-    END
-    END # Map File                      
+    MAP
+        NAME CGI-CONTEXT-DEMO
+        STATUS ON
+        SIZE 400 300
+        EXTENT -2200000 -712631 3072800 3840000
+        UNITS METERS
+        IMAGECOLOR 255 255 255
+        IMAGETYPE png
+        #
+        # Start of web interface definition
+        #
+        WEB
+          MINSCALE 2000000
+          MAXSCALE 50000000
+        #
+        # On Windows systems, /tmp and /tmp/ms_tmp/ should be created at the root 
+        # of the drive where the .MAP file resides.
+        #
+          IMAGEPATH "/ms4w/tmp/ms_tmp/" 
+          IMAGEURL "/ms_tmp/"
+        END
+    END # Map File

--- a/en/ogc/mapcontext.txt
+++ b/en/ogc/mapcontext.txt
@@ -18,7 +18,7 @@
 Introduction
 ============
  
-The term 'map context' comes from the Open Geospatial Constortium's (OGC) `Web
+The term 'map context' comes from the Open Geospatial Consortium's (OGC) `Web
 Map Context Specification v1.0.0`_, which coincides with the OGC `Web Map
 Server Specification (WMS) v1.1.1`_. A map context is a XML document that
 describes the appearance of layers from one or more WMS servers, and can be
@@ -385,103 +385,7 @@ Map Context Support Through CGI
 -------------------------------
 
 MapServer CGI allows you to load a map context through the use of a CONTEXT
-parameter, and you can point this parameter to a locally stored context file
-or a context file accessible through a URL. For more information on MapServer
-CGI see the :ref:`CGI Reference <cgi>`.
-
-Support for Local Map Context Files
-***********************************
-
-There is a new cgi parameter called *CONTEXT* that is used to specify a local
-context file. The user can then use MapServer to request a map using the
-following syntax:
-
-::
-
-    http://localhost/mapserver.cgi?MODE=map&MAP=/path/to/mapfile.map&CONTEXT=
-                         /path/to/contextfile.xml&LAYERS=layer_name1 layers_name2           
-                        
-.. note::
-
-    All layers created from a context file have their status set to ON. To be
-    able to display layers, the user needs to add the LAYERS argument in the
-    URL.
-
-Support for Context Files Accessed Through a URL
-************************************************
-
-The syntax of using a web accessible context file would be similar to accessing 
-a local context file:
-
-::
-
-    http://localhost/mapserver.cgi?MODE=map&MAP=/path/to/mapfile.map&CONTEXT=
-                http://URL/path/to/contextfile.xml&LAYERS=layers_name1 layer_name2     
-                        
-Due to security concerns loading a file from a URL is disabled by default. To enable 
-this functionality, the user needs to set a CONFIG parameter called *CGI_CONTEXT_URL* 
-in the default mapfile that will allow this functionality. Here is an example of a 
-map file with the CONFIG parameter:
-
-.. code-block:: mapfile
-
-    # Start of map file
-    NAME "map-context"
-    STATUS ON
-    SIZE 400 300
-    EXTENT -2200000 -712631 3072800 3840000
-    UNITS METERS
-    IMAGECOLOR 255 255 255
-    IMAGETYPE png
-    CONFIG "CGI_CONTEXT_URL" "1"
-    ...
-    WEB
-      ...
-    END
-    LAYER
-      ...
-    END 
-    
-    END
-                        
-Default Mapfile
-****************
-
-To smoothly run a MapServer CGI application with a Map Context, the
-application administrator needs to provide a default mapfile with at least the
-basic required parameters that will be used with the Context file. This
-default mapfile can contain as little information as the imagepath and
-imageurl or contain a list of layers. Information coming from the context
-(e.g.: layers, width, height, ...) would either be appended or will replace
-values found in the mapfile.
-
-Here is an example of a default map file containing the minimum required
-parameters:
-
-.. code-block:: mapfile
-    :linenos:
-    
-    NAME "CGI-CONTEXT-DEMO"
-    STATUS ON
-    SIZE 400 300
-    EXTENT -2200000 -712631 3072800 3840000
-    UNITS METERS
-    IMAGECOLOR 255 255 255
-    IMAGETYPE png
-    #
-    # Start of web interface definition
-    #
-    WEB
-      MINSCALE 2000000
-      MAXSCALE 50000000
-    #
-    # On Windows systems, /tmp and /tmp/ms_tmp/ should be created at the root 
-    # of the drive where the .MAP file resides.
-    #
-      IMAGEPATH "/ms4w/tmp/ms_tmp/" 
-      IMAGEURL "/ms_tmp/"
-    END
-    END # Map File                      
+parameter. See :ref:`mapcontext_cgi` for details.
 
 Map Context Support Through WMS
 -------------------------------


### PR DESCRIPTION
Adds a warning about remote file access when using `CGI_CONTEXT_URL`, and removes duplicated content between https://mapserver.org/cgi/mapcontext.html and https://mapserver.org/ogc/mapcontext.html (replaced with a link). 