### PR TITLE
Add back "Docs Preview" ribbon

### DIFF
--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -3,8 +3,8 @@
 {% block relbar1 %}
 
 
-<!-- for main branch only, do not backport this -->
 {%- if branch == 'main' %}
+<!-- add a ribbon to show these docs are the main branch -->
 <h4 class="ribbon">DOCS PREVIEW</h4>
 {%- endif %}
 

--- a/conf.py
+++ b/conf.py
@@ -11,7 +11,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys, os, shutil
+import sys, os
 import inspect
 from unittest.mock import MagicMock #py3 only
 
@@ -243,8 +243,8 @@ html_show_sourcelink = False
 html_theme = "classic"
 
 # Add the branch name as a variable that can be used in templates
-# this can be set as a sphinx-build option using `-A BRANCH=main`
-html_context = {'branch': release}
+# Defaults to 'local'if GIT_BRANCH isn't set (e.g. local builds)
+html_context = {'branch': os.environ.get('GIT_BRANCH', 'local')}
 
 # linkcheck options
 # -----------------


### PR DESCRIPTION
Follow-up to #1087
<img width="460" height="349" alt="image" src="https://github.com/user-attachments/assets/190336ae-efff-473e-b221-de25fad14d40" />

Also remove unused `shutil` from `conf.py`. 